### PR TITLE
Support setting group and user id of ssh user

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -8,7 +8,9 @@ RUN apt-get update \
         python3-pip \
         openssh-server \
     && rm -rf /var/lib/apt/lists/* \
-    && sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config
+    && sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config \
+    #  Remove default user to free up 1000 uid in case I want to use it
+    && userdel ubuntu
 
 COPY entrypoint.sh /tmp/
 

--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Setup ssh user
-adduser --disabled-password --gecos "" "$SSH_USER"
+addgroup --gid "$SSH_GROUP_ID" "$SSH_USER"
+adduser --disabled-password --gecos "" --uid "$SSH_USER_ID" --gid "$SSH_GROUP_ID" "$SSH_USER"
 mkdir -p "/home/$SSH_USER/.ssh/"
 echo "$SSH_PUB_KEY" > "/home/$SSH_USER/.ssh/authorized_keys"
 


### PR DESCRIPTION
This is useful if you are going to volume map a directory into the container and you want to permissions to be correct.