### PR TITLE
Add tauri devcontainer

### DIFF
--- a/.devcontainer/tauri/devcontainer.json
+++ b/.devcontainer/tauri/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "name": "Tauri",
+    "image": "mcr.microsoft.com/devcontainers/universal:2",
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    "features": {
+        "ghcr.io/devcontainers/features/rust:1": {},
+        "ghcr.io/devcontainers/features/desktop-lite:1": {},
+        "ghcr.io/devcontainers/features/node:1": {},
+        "sshd": "latest"
+    }
+}


### PR DESCRIPTION
This has rust, node, and desktop-lite since tauri is for making desktop applications.