### PR TITLE
Fix issue with select overwriting terminal text of previous command

### DIFF
--- a/wkfl/docs/why.md
+++ b/wkfl/docs/why.md
@@ -1,0 +1,7 @@
+# Why
+
+## Why stderr for prompts
+
+We use stderr because it allows you to pipe the output of the command to another
+command. If the prompt was also printed to stdout then it would get forwarded to
+the program and the user wouldn't see it.


### PR DESCRIPTION
The select prompt was moving up to far and causing it to overwrite the previous command. It also made the prompt look weird because it doesn't rerender some elements of the prompt and it was showing the wrong thing. I also made it handle being at the bottom of a terminal window and added a short doc about why we are using stderr.