### PR TITLE
Implement thinking model type for anthropic

### DIFF
--- a/wkfl/src/actions.rs
+++ b/wkfl/src/actions.rs
@@ -279,7 +279,17 @@ pub fn run_anthropic_query(maybe_query: Option<String>, config: Config) -> anyho
         max_tokens: 1024,
         ..anthropic::AnthropicRequest::default()
     })?;
-    println!("{}", result.content[0].text);
+    let content = result
+        .content
+        .into_iter()
+        .next()
+        .expect("It should always return some content");
+    println!(
+        "{}",
+        content
+            .text
+            .expect("text type content should have text field")
+    );
     Ok(())
 }
 


### PR DESCRIPTION
claude 3.7 added support for it, so might as well add it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configurable options for enhanced chat processing with updated model handling and adaptive token allocation.
  - Added refined message filtering to ensure only essential content is displayed.

- **Bug Fixes**
  - Improved error handling during result processing to better manage unexpected content gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->