### PR TITLE
Add streaming support to perplexity client

### DIFF
--- a/wkfl/src/actions.rs
+++ b/wkfl/src/actions.rs
@@ -277,14 +277,8 @@ pub fn stream_perplexity_query(maybe_query: Option<String>, config: Config) -> a
         ..perplexity::PerplexityRequest::default()
     })?;
     let mut citation_text = String::new();
-    result.for_each(|partial_result| {
-        let part = match partial_result {
-            Ok(result) => result,
-            Err(e) => {
-                eprintln!("Error: {}", e);
-                return;
-            }
-        };
+    for partial_result in result {
+        let part = partial_result?;
         if citation_text.is_empty() {
             if let Some(citations) = part.citations {
                 citation_text.push('\n');
@@ -299,8 +293,9 @@ pub fn stream_perplexity_query(maybe_query: Option<String>, config: Config) -> a
             }
         }
         print!("{}", part.choices[0].delta.content);
+        // This is a nice to have, so ignore any errors it returns
         std::io::stdout().flush().unwrap_or_default();
-    });
+    }
     println!("{}", citation_text);
     Ok(())
 }

--- a/wkfl/src/actions.rs
+++ b/wkfl/src/actions.rs
@@ -2,6 +2,7 @@ use anyhow::anyhow;
 use log::info;
 use std::fs;
 use std::io;
+use std::io::Write;
 use url::Url;
 
 use crate::config::get_repo_config;
@@ -297,7 +298,8 @@ pub fn stream_perplexity_query(maybe_query: Option<String>, config: Config) -> a
                 );
             }
         }
-        print!("{}", part.choices[0].delta.content)
+        print!("{}", part.choices[0].delta.content);
+        std::io::stdout().flush().unwrap_or_default();
     });
     println!("{}", citation_text);
     Ok(())

--- a/wkfl/src/main.rs
+++ b/wkfl/src/main.rs
@@ -100,6 +100,8 @@ enum LlmCommands {
     Perplexity {
         #[arg(value_hint = ValueHint::Other)]
         query: Option<String>,
+        #[arg(short, long)]
+        stream: bool,
     },
     VertexAi {
         #[arg(value_hint = ValueHint::Other)]
@@ -175,8 +177,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         Commands::Llm {
             command: llm_command,
         } => match llm_command {
-            LlmCommands::Perplexity { query } => {
-                actions::run_perplexity_query(query, context.config)?
+            LlmCommands::Perplexity { query, stream } => {
+                if stream {
+                    actions::stream_perplexity_query(query, context.config)?
+                } else {
+                    actions::run_perplexity_query(query, context.config)?
+                }
             }
             LlmCommands::Anthropic { query } => {
                 actions::run_anthropic_query(query, context.config)?


### PR DESCRIPTION
This could probably be cleaned up, but it is good enough for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced real-time streaming for chat interactions, displaying partial responses and accumulating citation details as they are received.
	- Added an option in the command-line interface to toggle between synchronous and streaming processing, enhancing user flexibility and interactivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->