### PR TITLE
Add left/right arrow key support to boolean prompt

### DIFF
--- a/wkfl/src/prompts.rs
+++ b/wkfl/src/prompts.rs
@@ -657,10 +657,10 @@ pub fn boolean_prompt(prompt: &str, default: bool) -> anyhow::Result<bool> {
                 KeyCode::Enter => {
                     break;
                 }
-                KeyCode::Char('l' | 'f' | 'n') => {
+                KeyCode::Char('l' | 'f' | 'n') | KeyCode::Right => {
                     state = false;
                 }
-                KeyCode::Char('h' | 't' | 'y') => {
+                KeyCode::Char('h' | 't' | 'y') | KeyCode::Left => {
                     state = true;
                 }
                 _ => {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded keyboard support for toggling boolean prompts by allowing the use of Left and Right arrow keys in addition to existing character keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->