### PR TITLE
Add command for pruning branches that have been merged

### DIFF
--- a/wkfl/src/clients.rs
+++ b/wkfl/src/clients.rs
@@ -1,0 +1,2 @@
+// Client modules for external APIs
+pub mod github;

--- a/wkfl/src/clients/github.rs
+++ b/wkfl/src/clients/github.rs
@@ -20,7 +20,12 @@ pub struct GitHubClient {
 
 impl GitHubClient {
     /// Create a new GitHub client
-    pub fn new(api_base: String, token: String) -> Self {
+    pub fn new(host: String, token: String) -> Self {
+        let api_base = if host == "github.com" {
+            "https://api.github.com".to_string()
+        } else {
+            format!("https://{}/api/v3", host)
+        };
         GitHubClient { api_base, token }
     }
 
@@ -36,13 +41,7 @@ impl GitHubClient {
             let mut segments = url
                 .path_segments_mut()
                 .map_err(|_| anyhow!("Failed to set URL path segments"))?;
-            segments
-                .push("repos")
-                .push(owner)
-                .push(repo)
-                .push("commits")
-                .push(commit_sha)
-                .push("pulls");
+            segments.extend(&["repos", owner, repo, "commits", commit_sha, "pulls"]);
         }
         let resp = ureq::get(url.as_str())
             .set("Authorization", &format!("Bearer {}", &self.token))

--- a/wkfl/src/clients/github.rs
+++ b/wkfl/src/clients/github.rs
@@ -1,0 +1,58 @@
+use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
+use ureq;
+use url::Url;
+/// A GitHub pull request minimal representation
+#[derive(Debug, Deserialize)]
+pub struct PullRequest {
+    pub number: i64,
+    #[serde(default)]
+    pub merged_at: Option<String>,
+    /// URL of the pull request on GitHub
+    pub html_url: String,
+}
+
+/// Client for interacting with the GitHub API
+pub struct GitHubClient {
+    api_base: String,
+    token: String,
+}
+
+impl GitHubClient {
+    /// Create a new GitHub client
+    pub fn new(api_base: String, token: String) -> Self {
+        GitHubClient { api_base, token }
+    }
+
+    /// List pull requests associated with a specific commit SHA
+    pub fn get_pull_requests_for_commit(
+        &self,
+        owner: &str,
+        repo: &str,
+        commit_sha: &str,
+    ) -> Result<Vec<PullRequest>> {
+        let mut url = Url::parse(&self.api_base)?;
+        {
+            let mut segments = url
+                .path_segments_mut()
+                .map_err(|_| anyhow!("Failed to set URL path segments"))?;
+            segments
+                .push("repos")
+                .push(owner)
+                .push(repo)
+                .push("commits")
+                .push(commit_sha)
+                .push("pulls");
+        }
+        let resp = ureq::get(url.as_str())
+            .set("Authorization", &format!("Bearer {}", &self.token))
+            .set("User-Agent", "wkfl")
+            .set("Accept", "application/vnd.github+json")
+            .call()
+            .with_context(|| format!("Failed to query GitHub API for commit '{}'", commit_sha))?;
+        let prs: Vec<PullRequest> = resp
+            .into_json()
+            .with_context(|| "Failed to parse GitHub PRs response as JSON")?;
+        Ok(prs)
+    }
+}

--- a/wkfl/src/config.rs
+++ b/wkfl/src/config.rs
@@ -9,6 +9,7 @@ use clap::ValueEnum;
 use home::home_dir;
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 use crate::llm::{
     anthropic::AnthropicClient, perplexity::PerplexityClient, vertex_ai::VertexAiClient, Chat,
@@ -62,6 +63,9 @@ pub struct Config {
     pub anthropic_api_key: Option<String>,
     pub perplexity_api_key: Option<String>,
     pub vertex_ai: Option<VertexAiConfig>,
+    /// GitHub API tokens mapped by host (e.g., github.com or github.example.com)
+    #[serde(default)]
+    pub github_tokens: HashMap<String, String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/wkfl/src/git.rs
+++ b/wkfl/src/git.rs
@@ -20,7 +20,7 @@ pub fn uses_worktrees(repo: &Repository) -> bool {
     repo.is_worktree() || repo.is_bare()
 }
 
-fn get_default_branch(repo: &Repository) -> anyhow::Result<String> {
+pub fn get_default_branch(repo: &Repository) -> anyhow::Result<String> {
     let head_ref = repo.find_reference("refs/remotes/origin/HEAD")?;
     let default_branch_ref = head_ref.symbolic_target().ok_or(anyhow::anyhow!(
         "origin/HEAD doesn't point to branch, can't determine default branch"

--- a/wkfl/src/main.rs
+++ b/wkfl/src/main.rs
@@ -7,6 +7,7 @@ use llm::ModelType;
 use notes::DailyNoteSpecifier;
 
 mod actions;
+mod clients;
 mod config;
 mod git;
 mod llm;
@@ -37,6 +38,8 @@ enum Commands {
     Repo,
     Config,
     Clone,
+    /// List all local branches and delete those whose pull request has been merged
+    PruneBranches,
     Confirm {
         #[arg(value_hint = ValueHint::Other)]
         prompt: Option<String>,
@@ -149,6 +152,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         Commands::Repos => actions::list_repositories(context.config)?,
         Commands::Repo => actions::switch_repo(&mut context)?,
         Commands::Clone => actions::clone_repo(&mut context)?,
+        Commands::PruneBranches => actions::prune_merged_branches(&context.config)?,
         Commands::Config => actions::print_config(context.config),
         Commands::Confirm {
             prompt: user_prompt,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a CLI subcommand to list and delete local branches with merged pull requests on GitHub.
  - Enabled configuration of GitHub API tokens for multiple hosts.
  - Introduced a GitHub API client for enhanced interaction with GitHub services.
- **Improvements**
  - Improved GitHub integration to check pull request statuses by commit.
- **Documentation**
  - Updated CLI help to include the branch pruning feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->