### PR TITLE
Add a build command to along with the fmt and test commands

### DIFF
--- a/wkfl/src/actions.rs
+++ b/wkfl/src/actions.rs
@@ -703,6 +703,20 @@ pub fn run_fmt_commands(_context: &mut Context) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub fn run_build_commands(_context: &mut Context) -> anyhow::Result<()> {
+    let repo = git::get_repository()?;
+    let repo_root = determine_repo_root_dir(&repo);
+    let repo_config = get_repo_config(repo_root)?;
+
+    if repo_config.build_commands.is_empty() {
+        println!("No build commands configured in repository config");
+        return Ok(());
+    }
+
+    utils::run_commands_with_output(&repo_config.build_commands)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::extract_owner_repo_from_url;

--- a/wkfl/src/config.rs
+++ b/wkfl/src/config.rs
@@ -83,6 +83,8 @@ pub struct RepoConfig {
     pub test_commands: Vec<String>,
     #[serde(default)]
     pub fmt_commands: Vec<String>,
+    #[serde(default)]
+    pub build_commands: Vec<String>,
 }
 
 impl RepoConfig {
@@ -104,6 +106,9 @@ impl RepoConfig {
         }
         if !other.fmt_commands.is_empty() {
             self.fmt_commands = other.fmt_commands;
+        }
+        if !other.build_commands.is_empty() {
+            self.build_commands = other.build_commands;
         }
         self
     }
@@ -261,6 +266,7 @@ mod tests {
             post_end_commands: vec![],
             test_commands: vec![],
             fmt_commands: vec![],
+            build_commands: vec![],
         };
         let other = RepoConfig {
             pre_start_commands: vec![],
@@ -269,6 +275,7 @@ mod tests {
             post_end_commands: vec![],
             test_commands: vec![],
             fmt_commands: vec![],
+            build_commands: vec![],
         };
 
         let result = base.merge_with(other);
@@ -279,6 +286,7 @@ mod tests {
         assert!(result.post_end_commands.is_empty());
         assert!(result.test_commands.is_empty());
         assert!(result.fmt_commands.is_empty());
+        assert!(result.build_commands.is_empty());
     }
 
     #[test]
@@ -290,6 +298,7 @@ mod tests {
             post_end_commands: vec!["base_post_end".to_string()],
             test_commands: vec!["base_test".to_string()],
             fmt_commands: vec!["base_fmt".to_string()],
+            build_commands: vec!["base_build".to_string()],
         };
         let other = RepoConfig {
             pre_start_commands: vec![],
@@ -298,6 +307,7 @@ mod tests {
             post_end_commands: vec![],
             test_commands: vec![],
             fmt_commands: vec![],
+            build_commands: vec![],
         };
 
         let result = base.merge_with(other);
@@ -308,6 +318,7 @@ mod tests {
         assert_eq!(result.post_end_commands, vec!["base_post_end"]);
         assert_eq!(result.test_commands, vec!["base_test"]);
         assert_eq!(result.fmt_commands, vec!["base_fmt"]);
+        assert_eq!(result.build_commands, vec!["base_build"]);
     }
 
     #[test]
@@ -319,6 +330,7 @@ mod tests {
             post_end_commands: vec![],
             test_commands: vec![],
             fmt_commands: vec![],
+            build_commands: vec![],
         };
         let other = RepoConfig {
             pre_start_commands: vec!["other_pre_start".to_string()],
@@ -327,6 +339,7 @@ mod tests {
             post_end_commands: vec!["other_post_end".to_string()],
             test_commands: vec!["other_test".to_string()],
             fmt_commands: vec!["other_fmt".to_string()],
+            build_commands: vec!["other_build".to_string()],
         };
 
         let result = base.merge_with(other);
@@ -337,6 +350,7 @@ mod tests {
         assert_eq!(result.post_end_commands, vec!["other_post_end"]);
         assert_eq!(result.test_commands, vec!["other_test"]);
         assert_eq!(result.fmt_commands, vec!["other_fmt"]);
+        assert_eq!(result.build_commands, vec!["other_build"]);
     }
 
     #[test]
@@ -348,6 +362,7 @@ mod tests {
             post_end_commands: vec!["base_post_end".to_string()],
             test_commands: vec!["base_test".to_string()],
             fmt_commands: vec!["base_fmt".to_string()],
+            build_commands: vec!["base_build".to_string()],
         };
         let other = RepoConfig {
             pre_start_commands: vec!["other_pre_start".to_string()],
@@ -356,6 +371,7 @@ mod tests {
             post_end_commands: vec!["other_post_end".to_string()],
             test_commands: vec!["other_test".to_string()],
             fmt_commands: vec!["other_fmt".to_string()],
+            build_commands: vec!["other_build".to_string()],
         };
 
         let result = base.merge_with(other);
@@ -366,6 +382,7 @@ mod tests {
         assert_eq!(result.post_end_commands, vec!["other_post_end"]);
         assert_eq!(result.test_commands, vec!["other_test"]);
         assert_eq!(result.fmt_commands, vec!["other_fmt"]);
+        assert_eq!(result.build_commands, vec!["other_build"]);
     }
 
     #[test]
@@ -377,6 +394,7 @@ mod tests {
             post_end_commands: vec!["base_post_end".to_string()],
             test_commands: vec!["base_test".to_string()],
             fmt_commands: vec!["base_fmt".to_string()],
+            build_commands: vec!["base_build".to_string()],
         };
         let other = RepoConfig {
             pre_start_commands: vec![], // Empty, should not override
@@ -385,6 +403,7 @@ mod tests {
             post_end_commands: vec![],  // Empty, should not override
             test_commands: vec!["other_test1".to_string(), "other_test2".to_string()], // Should override
             fmt_commands: vec![], // Empty, should not override
+            build_commands: vec!["other_build1".to_string(), "other_build2".to_string()], // Should override
         };
 
         let result = base.merge_with(other);
@@ -395,6 +414,8 @@ mod tests {
         assert_eq!(result.post_end_commands, vec!["base_post_end"]); // Kept from base
         assert_eq!(result.test_commands, vec!["other_test1", "other_test2"]); // Overridden
         assert_eq!(result.fmt_commands, vec!["base_fmt"]); // Kept from base
+        assert_eq!(result.build_commands, vec!["other_build1", "other_build2"]);
+        // Overridden
     }
 
     #[test]
@@ -406,6 +427,7 @@ mod tests {
             post_end_commands: vec![],
             test_commands: vec![],
             fmt_commands: vec![],
+            build_commands: vec![],
         };
         let other = RepoConfig {
             pre_start_commands: vec![], // Should not override
@@ -418,6 +440,7 @@ mod tests {
             post_end_commands: vec![],
             test_commands: vec!["test1".to_string()],
             fmt_commands: vec![],
+            build_commands: vec!["build1".to_string()],
         };
 
         let result = base.merge_with(other);
@@ -431,6 +454,7 @@ mod tests {
         assert!(result.post_end_commands.is_empty());
         assert_eq!(result.test_commands, vec!["test1"]); // From other
         assert!(result.fmt_commands.is_empty()); // Empty from both
+        assert_eq!(result.build_commands, vec!["build1"]); // From other
     }
 
     #[test]
@@ -442,6 +466,7 @@ mod tests {
             post_end_commands: vec![],
             test_commands: vec![],
             fmt_commands: vec![],
+            build_commands: vec![],
         };
         let middle = RepoConfig {
             pre_start_commands: vec![], // Should not override
@@ -450,6 +475,7 @@ mod tests {
             post_end_commands: vec![],
             test_commands: vec![],
             fmt_commands: vec!["middle_fmt".to_string()],
+            build_commands: vec!["middle_build".to_string()],
         };
         let final_config = RepoConfig {
             pre_start_commands: vec!["final".to_string()], // Should override
@@ -457,7 +483,8 @@ mod tests {
             pre_end_commands: vec![],
             post_end_commands: vec![],
             test_commands: vec!["final_test".to_string()],
-            fmt_commands: vec![], // Should not override
+            fmt_commands: vec![],   // Should not override
+            build_commands: vec![], // Should not override
         };
 
         let result = base.merge_with(middle).merge_with(final_config);
@@ -468,5 +495,6 @@ mod tests {
         assert!(result.post_end_commands.is_empty());
         assert_eq!(result.test_commands, vec!["final_test"]); // From final
         assert_eq!(result.fmt_commands, vec!["middle_fmt"]); // From middle (final is empty)
+        assert_eq!(result.build_commands, vec!["middle_build"]); // From middle (final is empty)
     }
 }

--- a/wkfl/src/main.rs
+++ b/wkfl/src/main.rs
@@ -45,6 +45,8 @@ enum Commands {
     Test,
     /// Run fmt commands defined in repo config
     Fmt,
+    /// Run build commands defined in repo config
+    Build,
     Confirm {
         #[arg(value_hint = ValueHint::Other)]
         prompt: Option<String>,
@@ -162,6 +164,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         Commands::PruneBranches => actions::prune_merged_branches(&context.config)?,
         Commands::Test => actions::run_test_commands(&mut context)?,
         Commands::Fmt => actions::run_fmt_commands(&mut context)?,
+        Commands::Build => actions::run_build_commands(&mut context)?,
         Commands::Config => actions::print_config(context.config),
         Commands::Confirm {
             prompt: user_prompt,

--- a/wkfl/src/mcp.rs
+++ b/wkfl/src/mcp.rs
@@ -290,6 +290,52 @@ impl McpServer {
                     required: None,
                 }),
             },
+            Tool {
+                name: "get_build_commands".to_string(),
+                title: Some("Get Build Commands".to_string()),
+                description: Some(
+                    "Get build commands configured in the repository's .wkfl.toml config"
+                        .to_string(),
+                ),
+                input_schema: ToolInputSchema {
+                    schema_type: "object".to_string(),
+                    properties: Some({
+                        let mut props = HashMap::new();
+                        props.insert(
+                            "repo_path".to_string(),
+                            json!({
+                                "type": "string",
+                                "description": "Path to the repository root directory"
+                            }),
+                        );
+                        props
+                    }),
+                    required: Some(vec!["repo_path".to_string()]),
+                },
+                output_schema: Some(ToolOutputSchema {
+                    schema_type: "object".to_string(),
+                    properties: Some({
+                        let mut props = HashMap::new();
+                        props.insert(
+                            "commands".to_string(),
+                            json!({
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "List of build commands"
+                            }),
+                        );
+                        props.insert(
+                            "error".to_string(),
+                            json!({
+                                "type": "string",
+                                "description": "Error message if command retrieval failed"
+                            }),
+                        );
+                        props
+                    }),
+                    required: None,
+                }),
+            },
         ];
 
         Self {
@@ -370,7 +416,7 @@ impl McpServer {
             "protocolVersion": LATEST_PROTOCOL_VERSION,
             "capabilities": self.capabilities,
             "serverInfo": self.server_info,
-            "instructions": "This is a wkfl MCP server that provides tools for retrieving test and format commands from repository configuration."
+            "instructions": "This is a wkfl MCP server that provides tools for retrieving test, format, and build commands from repository configuration."
         });
 
         let response = JSONRPCResponse {
@@ -404,6 +450,7 @@ impl McpServer {
         let result = match tool_name {
             "get_test_commands" => self.get_test_commands(arguments),
             "get_fmt_commands" => self.get_fmt_commands(arguments),
+            "get_build_commands" => self.get_build_commands(arguments),
             _ => CallToolResult {
                 content: vec![TextContent {
                     content_type: "text".to_string(),
@@ -509,5 +556,9 @@ impl McpServer {
 
     fn get_fmt_commands(&self, args: &Value) -> CallToolResult {
         self.get_commands_from_config(args, "format", |config| config.fmt_commands.clone())
+    }
+
+    fn get_build_commands(&self, args: &Value) -> CallToolResult {
+        self.get_commands_from_config(args, "build", |config| config.build_commands.clone())
     }
 }


### PR DESCRIPTION
I had some commands that didn't fit in the fmt or tests command list very well, so adding a build list of commands to fill the gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining and running build commands from the repository configuration via a new CLI command.
  * Introduced a new tool to retrieve build commands through the MCP server.
* **Enhancements**
  * Repository configuration now supports a list of build commands, with improved merging behavior.
  * Command-line interface updated with a new "Build" command option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->