### PR TITLE
Add flag for printing the full path of the repos

### DIFF
--- a/wkfl/src/actions.rs
+++ b/wkfl/src/actions.rs
@@ -123,12 +123,16 @@ pub fn end_workflow() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn list_repositories(config: Config) -> anyhow::Result<()> {
+pub fn list_repositories(config: Config, full_path: bool) -> anyhow::Result<()> {
     let base_repo_path = config.repositories_directory_path()?;
     let repo_paths = get_repositories_in_directory(&base_repo_path)?;
     for repo_path in repo_paths {
-        let relative_repo_path = repo_path.strip_prefix(&base_repo_path)?;
-        println!("{}", relative_repo_path.display())
+        if full_path {
+            println!("{}", repo_path.display())
+        } else {
+            let relative_repo_path = repo_path.strip_prefix(&base_repo_path)?;
+            println!("{}", relative_repo_path.display())
+        }
     }
     Ok(())
 }

--- a/wkfl/src/main.rs
+++ b/wkfl/src/main.rs
@@ -35,7 +35,10 @@ enum Commands {
     Start,
     End,
     RepoDebug,
-    Repos,
+    Repos {
+        #[arg(short, long)]
+        full_path: bool,
+    },
     Repo,
     Config,
     Clone,
@@ -158,7 +161,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         Commands::Start => actions::start_workflow(&mut context)?,
         Commands::End => actions::end_workflow()?,
         Commands::RepoDebug => actions::print_repo_debug_info()?,
-        Commands::Repos => actions::list_repositories(context.config)?,
+        Commands::Repos { full_path } => actions::list_repositories(context.config, full_path)?,
         Commands::Repo => actions::switch_repo(&mut context)?,
         Commands::Clone => actions::clone_repo(&mut context)?,
         Commands::PruneBranches => actions::prune_merged_branches(&context.config)?,


### PR DESCRIPTION
This is useful if other commands need to consume the output and don't know the base path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to display either full absolute paths or relative paths when listing repositories via the command-line interface. Users can now choose their preferred path format with a new command-line flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->