### PR TITLE
Add a todo edit command that opens the todo file for manually editting

### DIFF
--- a/wkfl/src/main.rs
+++ b/wkfl/src/main.rs
@@ -184,6 +184,8 @@ enum TodoCommands {
         #[arg(value_hint = ValueHint::Other, help = "1-based index of the item to mark as pending")]
         index: Option<usize>,
     },
+    #[command(about = "Open the todo.md file in the default editor")]
+    Edit,
 }
 
 #[derive(Subcommand, Debug)]
@@ -362,6 +364,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             TodoCommands::Remove { index } => todo::remove_todo(&context.config, index)?,
             TodoCommands::Check { index } => todo::check_todo(&context.config, index)?,
             TodoCommands::Uncheck { index } => todo::uncheck_todo(&context.config, index)?,
+            TodoCommands::Edit => todo::edit_todo(&mut context)?,
         },
     };
 

--- a/wkfl/src/todo.rs
+++ b/wkfl/src/todo.rs
@@ -5,8 +5,11 @@ use std::path::PathBuf;
 
 use crate::config::Config;
 use crate::prompts::select_prompt;
+use crate::shell_actions::ShellAction;
+use crate::Context;
 
 const SPACES_PER_INDENT: usize = 4;
+const TODO_FILENAME: &str = "todo.md";
 
 #[derive(Debug, Clone)]
 pub struct TodoItem {
@@ -75,7 +78,7 @@ impl TodoFile {
     }
 
     pub fn load(notes_directory: PathBuf) -> Result<Self> {
-        let file_path = notes_directory.join("todo.md");
+        let file_path = notes_directory.join(TODO_FILENAME);
 
         if !file_path.exists() {
             return Ok(TodoFile {
@@ -382,5 +385,25 @@ pub fn uncheck_todo(config: &Config, user_index: Option<usize>) -> Result<()> {
 
     let item_description = todo_file.items[index - 1].description.clone();
     println!("Marked as pending: {}", item_description);
+    Ok(())
+}
+
+pub fn edit_todo(context: &mut Context) -> Result<()> {
+    let notes_directory = context.config.notes_directory_path()?;
+    let todo_file_path = notes_directory.join(TODO_FILENAME);
+
+    // Ensure the todo file exists by creating an empty one if it doesn't
+    if !todo_file_path.exists() {
+        let empty_todo_file = TodoFile {
+            items: Vec::new(),
+            file_path: todo_file_path.clone(),
+        };
+        empty_todo_file.save()?;
+    }
+
+    context.shell_actions.push(ShellAction::EditFile {
+        path: todo_file_path,
+    });
+
     Ok(())
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an edit subcommand to open your todo.md in the default editor.
  * Automatically creates todo.md if it doesn’t exist, ensuring a smooth first run.
  * Respects your configured notes directory when locating the todo file.
  * Consistent use of todo.md improves predictability across workflows and environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->