### PR TITLE
Add JSON output for Jira commands

### DIFF
--- a/wkfl/src/actions.rs
+++ b/wkfl/src/actions.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use log::info;
+use serde::Serialize;
 use std::fs;
 use std::io;
 use std::io::Write;
@@ -856,9 +857,18 @@ fn print_comments_markdown(
     Ok(())
 }
 
-pub fn get_jira_issue(issue_key: &str, config: &Config) -> anyhow::Result<()> {
+fn print_json<T: Serialize>(value: &T) -> anyhow::Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+pub fn get_jira_issue(issue_key: &str, json: bool, config: &Config) -> anyhow::Result<()> {
     let client = create_jira_client(config)?;
     let issue = client.get_issue(issue_key)?;
+
+    if json {
+        return print_json(&issue);
+    }
 
     println!("Issue: {}", issue.key);
     println!("Summary: {}", issue.fields.summary);
@@ -949,18 +959,35 @@ fn display_jira_issues(issues: &[crate::jira::Issue]) {
 pub fn search_jira_issues(
     jql: &str,
     max_results: Option<u32>,
+    json: bool,
     config: &Config,
 ) -> anyhow::Result<()> {
     let client = create_jira_client(config)?;
     let issues = client.search_issues(jql, max_results)?;
 
+    if json {
+        return print_json(&issues);
+    }
+
     display_jira_issues(&issues);
     Ok(())
+}
+
+#[derive(Serialize)]
+struct JiraFilterSearchOutput<'a> {
+    filter: &'a crate::jira::Filter,
+    issues: &'a [crate::jira::Issue],
+}
+
+#[derive(Serialize)]
+struct JiraFilterSearchError<'a> {
+    error: &'a str,
 }
 
 pub fn search_jira_issues_by_filter(
     filter_id: Option<String>,
     max_results: Option<u32>,
+    json: bool,
     config: &Config,
 ) -> anyhow::Result<()> {
     let client = create_jira_client(config)?;
@@ -977,9 +1004,13 @@ pub fn search_jira_issues_by_filter(
             let filters = client.get_favourite_filters()?;
 
             if filters.is_empty() {
-                println!(
-                    "No favourite filters found. You can add filters to your favourites in Jira."
-                );
+                let message =
+                    "No favourite filters found. You can add filters to your favourites in Jira.";
+                if json {
+                    return print_json(&JiraFilterSearchError { error: message });
+                }
+
+                println!("{}", message);
                 return Ok(());
             }
 
@@ -1001,11 +1032,19 @@ pub fn search_jira_issues_by_filter(
         "Executing search with filter: {} (ID: {})",
         filter.name, filter.id
     );
+    // Search for issues using the filter's JQL
+    let issues = client.search_issues(&filter.jql, max_results)?;
+
+    if json {
+        return print_json(&JiraFilterSearchOutput {
+            filter: &filter,
+            issues: &issues,
+        });
+    }
+
     println!("Using filter: {} ({})", filter.name, filter.jql);
     println!();
 
-    // Search for issues using the filter's JQL
-    let issues = client.search_issues(&filter.jql, max_results)?;
     display_jira_issues(&issues);
     Ok(())
 }

--- a/wkfl/src/jira.rs
+++ b/wkfl/src/jira.rs
@@ -2,13 +2,13 @@ use crate::config::resolve_secret;
 use crate::config::Config;
 use anyhow::{anyhow, Context, Result};
 use base64::{engine::general_purpose, Engine as _};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 pub mod adf;
 
 /// A Jira issue minimal representation
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Issue {
     #[allow(dead_code)]
     pub id: String,
@@ -17,7 +17,7 @@ pub struct Issue {
 }
 
 /// Jira issue fields
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct IssueFields {
     pub summary: String,
     pub description: Option<adf::Document>,
@@ -32,12 +32,12 @@ pub struct IssueFields {
     pub comment: CommentBlock,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CommentBlock {
     pub comments: Vec<Comment>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Project {
     #[allow(dead_code)]
     pub id: String,
@@ -46,20 +46,20 @@ pub struct Project {
 }
 
 /// A Jira user
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct User {
-    #[serde(rename = "accountId")]
+    #[serde(rename = "accountId", skip_serializing)]
     #[allow(dead_code)]
     pub account_id: String,
     #[serde(rename = "displayName")]
     pub display_name: String,
-    #[serde(rename = "emailAddress")]
+    #[serde(rename = "emailAddress", skip_serializing)]
     #[allow(dead_code)]
     pub email_address: Option<String>,
 }
 
 /// Jira issue status
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Status {
     #[allow(dead_code)]
     pub id: String,
@@ -70,7 +70,7 @@ pub struct Status {
 }
 
 /// Jira status category
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct StatusCategory {
     #[allow(dead_code)]
     pub key: String,
@@ -79,7 +79,7 @@ pub struct StatusCategory {
 }
 
 /// Jira issue priority
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Priority {
     #[allow(dead_code)]
     pub id: String,
@@ -87,7 +87,7 @@ pub struct Priority {
 }
 
 /// Jira issue type
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct IssueType {
     #[allow(dead_code)]
     pub id: String,
@@ -97,7 +97,7 @@ pub struct IssueType {
 }
 
 /// A Jira comment
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Comment {
     #[allow(dead_code)]
     pub id: String,
@@ -112,7 +112,7 @@ pub struct Comment {
 ///
 /// Filters in Jira are saved JQL queries that can be reused to search for issues.
 /// They can be marked as favourites and shared with other users.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Filter {
     /// Unique identifier for the filter
     pub id: String,
@@ -341,6 +341,25 @@ pub fn format_jira_date(date_str: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_user_deserializes_but_does_not_serialize_pii() {
+        let user: User = serde_json::from_value(serde_json::json!({
+            "accountId": "user123",
+            "displayName": "Test User",
+            "emailAddress": "test@example.com"
+        }))
+        .unwrap();
+
+        assert_eq!(user.account_id, "user123");
+        assert_eq!(user.email_address.as_deref(), Some("test@example.com"));
+
+        let serialized = serde_json::to_value(&user).unwrap();
+
+        assert_eq!(serialized["displayName"], "Test User");
+        assert!(serialized.get("accountId").is_none());
+        assert!(serialized.get("emailAddress").is_none());
+    }
 
     #[test]
     fn test_format_jira_date_with_timezone_plus() {

--- a/wkfl/src/main.rs
+++ b/wkfl/src/main.rs
@@ -282,6 +282,9 @@ enum JiraCommands {
         /// Issue key to fetch (for example, PROJ-123).
         #[arg(value_hint = ValueHint::Other)]
         issue_key: String,
+        /// Output the issue as JSON.
+        #[arg(long)]
+        json: bool,
     },
     /// Search Jira issues using a JQL query.
     Search {
@@ -291,6 +294,9 @@ enum JiraCommands {
         /// Maximum number of results to return.
         #[arg(short, long)]
         max_results: Option<u32>,
+        /// Output matching issues as JSON.
+        #[arg(long)]
+        json: bool,
     },
     /// Search Jira issues using a saved filter.
     Filter {
@@ -300,6 +306,9 @@ enum JiraCommands {
         /// Maximum number of results to return.
         #[arg(short, long)]
         max_results: Option<u32>,
+        /// Output the filter and matching issues as JSON.
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -454,16 +463,24 @@ fn main() -> Result<(), Box<dyn Error>> {
         Commands::Jira {
             command: jira_command,
         } => match jira_command {
-            JiraCommands::Get { issue_key } => {
-                actions::get_jira_issue(&issue_key, &context.config)?
+            JiraCommands::Get { issue_key, json } => {
+                actions::get_jira_issue(&issue_key, json, &context.config)?
             }
-            JiraCommands::Search { jql, max_results } => {
-                actions::search_jira_issues(&jql, max_results, &context.config)?
-            }
+            JiraCommands::Search {
+                jql,
+                max_results,
+                json,
+            } => actions::search_jira_issues(&jql, max_results, json, &context.config)?,
             JiraCommands::Filter {
                 filter_id,
                 max_results,
-            } => actions::search_jira_issues_by_filter(filter_id, max_results, &context.config)?,
+                json,
+            } => actions::search_jira_issues_by_filter(
+                filter_id,
+                max_results,
+                json,
+                &context.config,
+            )?,
         },
     };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --json flag to Jira commands (jira get, jira search, jira filter) to emit machine-readable JSON.
  * JSON output includes single-issue details, search result lists, and selected filter metadata plus matched issues.
  * When --json is used, human-friendly banners/tables are suppressed.
  * If no favorite filters exist and --json is used, an error is returned as JSON.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kdeal/misc/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->