### PR TITLE
Add support for json output to GitHub commands

### DIFF
--- a/wkfl/src/actions.rs
+++ b/wkfl/src/actions.rs
@@ -613,6 +613,7 @@ pub fn run_build_commands(_context: &mut Context, list: bool) -> anyhow::Result<
 
 pub fn get_pull_request_for_commit(
     commit_sha: Option<String>,
+    json: bool,
     config: &Config,
 ) -> anyhow::Result<()> {
     let repo = git::get_repository()?;
@@ -628,6 +629,10 @@ pub fn get_pull_request_for_commit(
 
     let github_client = create_github_client(&remote_url, config)?;
     let pull_requests = github_client.get_pull_requests_for_commit(&owner, &repo_name, &sha)?;
+
+    if json {
+        return print_json(&pull_requests);
+    }
 
     if pull_requests.is_empty() {
         println!("No pull request found for commit {sha}");
@@ -650,6 +655,7 @@ pub fn get_pr_comments(
     filter_timeline: bool,
     filter_bots: bool,
     filter_diff: bool,
+    json: bool,
     config: &Config,
 ) -> anyhow::Result<()> {
     let repo = git::get_repository()?;
@@ -673,9 +679,62 @@ pub fn get_pr_comments(
 
     let comments = github_client.get_pr_comments(&owner, &repo_name, pr_num)?;
 
+    if json {
+        return print_comments_json(&comments, filter_timeline, filter_bots, filter_diff);
+    }
+
     print_comments_markdown(&comments, filter_timeline, filter_bots, filter_diff)?;
 
     Ok(())
+}
+
+#[derive(Serialize)]
+struct PrCommentsOutput<'a> {
+    issue_comments: Vec<&'a IssueComment>,
+    review_comments: Vec<&'a ReviewComment>,
+}
+
+fn filtered_comments<'a>(
+    comments: &'a PrComments,
+    filter_timeline: bool,
+    filter_bots: bool,
+    filter_diff: bool,
+) -> PrCommentsOutput<'a> {
+    let mut issue_comments = if filter_timeline {
+        Vec::new()
+    } else {
+        comments.issue_comments.iter().collect()
+    };
+
+    let mut review_comments = if filter_diff {
+        Vec::new()
+    } else {
+        comments.review_comments.iter().collect()
+    };
+
+    if filter_bots {
+        issue_comments.retain(|c| !is_bot_user(&c.user.login, &c.user.user_type));
+        review_comments.retain(|c| !is_bot_user(&c.user.login, &c.user.user_type));
+    }
+
+    PrCommentsOutput {
+        issue_comments,
+        review_comments,
+    }
+}
+
+fn print_comments_json(
+    comments: &PrComments,
+    filter_timeline: bool,
+    filter_bots: bool,
+    filter_diff: bool,
+) -> anyhow::Result<()> {
+    print_json(&filtered_comments(
+        comments,
+        filter_timeline,
+        filter_bots,
+        filter_diff,
+    ))
 }
 
 fn format_context_lines(diff_lines: &[&git::DiffLine]) -> String {

--- a/wkfl/src/github.rs
+++ b/wkfl/src/github.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use url::Url;
 /// A GitHub pull request minimal representation
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PullRequest {
     pub number: u64,
     #[serde(default)]
@@ -21,7 +21,7 @@ pub struct PullRequest {
 }
 
 /// A GitHub user
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct User {
     pub login: String,
     #[serde(rename = "type")]
@@ -29,7 +29,7 @@ pub struct User {
 }
 
 /// A GitHub issue/PR comment (timeline comment)
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct IssueComment {
     pub body: String,
     pub user: User,
@@ -37,7 +37,7 @@ pub struct IssueComment {
 }
 
 /// A GitHub pull request review comment (diff comment)
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ReviewComment {
     pub body: String,
     pub user: User,
@@ -56,7 +56,7 @@ pub struct ReviewComment {
 }
 
 /// Container for all PR comment types
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct PrComments {
     pub issue_comments: Vec<IssueComment>,
     pub review_comments: Vec<ReviewComment>,

--- a/wkfl/src/main.rs
+++ b/wkfl/src/main.rs
@@ -171,6 +171,9 @@ enum GithubCommands {
         /// Commit SHA to inspect (defaults to the current HEAD).
         #[arg(value_hint = ValueHint::Other)]
         commit_sha: Option<String>,
+        /// Output matching pull requests as JSON.
+        #[arg(long)]
+        json: bool,
     },
     /// Print comments for a pull request.
     #[command(name = "get_pr_comments")]
@@ -187,6 +190,9 @@ enum GithubCommands {
         /// Exclude diff review comments from the output.
         #[arg(long)]
         filter_diff: bool,
+        /// Output matching comments as JSON.
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -425,19 +431,21 @@ fn main() -> Result<(), Box<dyn Error>> {
         Commands::Github {
             command: github_command,
         } => match github_command {
-            GithubCommands::GetPr { commit_sha } => {
-                actions::get_pull_request_for_commit(commit_sha, &context.config)?
+            GithubCommands::GetPr { commit_sha, json } => {
+                actions::get_pull_request_for_commit(commit_sha, json, &context.config)?
             }
             GithubCommands::GetPrComments {
                 pr_number,
                 filter_timeline,
                 no_filter_bots,
                 filter_diff,
+                json,
             } => actions::get_pr_comments(
                 pr_number,
                 filter_timeline,
                 !no_filter_bots,
                 filter_diff,
+                json,
                 &context.config,
             )?,
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--json` flag to pull request query command for JSON-formatted output.
  * Added `--json` flag to PR comments command for JSON-formatted output, supporting optional filtering of bot comments and timeline entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kdeal/misc/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->