### PR TITLE
Add support for json output to repos command

### DIFF
--- a/wkfl/src/actions.rs
+++ b/wkfl/src/actions.rs
@@ -31,20 +31,43 @@ use crate::shell_actions::ShellAction;
 use crate::utils;
 use crate::Context;
 
-pub fn list_repositories(config: Config, full_path: bool) -> anyhow::Result<()> {
-    let base_repo_path = config.repositories_directory_path()?;
-    let repo_paths = get_repositories_in_directory(&base_repo_path)?;
-    for repo_path in repo_paths {
-        if full_path {
-            println!("{}", repo_path.display())
-        } else {
-            let relative_repo_path = repo_path.strip_prefix(&base_repo_path)?;
-            println!("{}", relative_repo_path.display())
-        }
-    }
-    Ok(())
+#[derive(Serialize)]
+struct RepositoriesOutput {
+    base_directory: String,
+    repos: Vec<String>,
 }
 
+pub fn list_repositories(config: Config, full_path: bool, json: bool) -> anyhow::Result<()> {
+    let base_repo_path = config.repositories_directory_path()?;
+    let repo_paths = get_repositories_in_directory(&base_repo_path)?;
+
+    let repos: Vec<String> = repo_paths
+        .iter()
+        .map(|repo_path| {
+            if full_path {
+                Ok(repo_path.display().to_string())
+            } else {
+                Ok(repo_path
+                    .strip_prefix(&base_repo_path)?
+                    .display()
+                    .to_string())
+            }
+        })
+        .collect::<anyhow::Result<_>>()?;
+
+    if json {
+        return print_json(&RepositoriesOutput {
+            base_directory: base_repo_path.display().to_string(),
+            repos,
+        });
+    }
+
+    for repo in repos {
+        println!("{}", repo)
+    }
+
+    Ok(())
+}
 pub fn switch_repo(context: &mut Context) -> anyhow::Result<()> {
     let base_repo_path = context.config.repositories_directory_path()?;
     let repo_paths = get_repositories_in_directory(&base_repo_path)?;

--- a/wkfl/src/main.rs
+++ b/wkfl/src/main.rs
@@ -43,6 +43,9 @@ enum Commands {
         /// Show absolute paths instead of relative names.
         #[arg(short, long)]
         full_path: bool,
+        /// Output repositories as JSON.
+        #[arg(long)]
+        json: bool,
     },
     /// Select a repository and switch to it.
     Repo,
@@ -347,7 +350,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
     match cli.command {
         Commands::RepoDebug => actions::print_repo_debug_info()?,
-        Commands::Repos { full_path } => actions::list_repositories(context.config, full_path)?,
+        Commands::Repos { full_path, json } => {
+            actions::list_repositories(context.config, full_path, json)?
+        }
         Commands::Repo => actions::switch_repo(&mut context)?,
         Commands::Clone => actions::clone_repo(&mut context)?,
         Commands::PruneBranches => actions::prune_merged_branches(&context.config)?,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--json` flag to the repositories listing command, enabling structured JSON output of repository paths and metadata instead of plain text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kdeal/misc/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->