### PR TITLE
By default don't include my teams prs in prs_to_review

### DIFF
--- a/wkfl/src/actions.rs
+++ b/wkfl/src/actions.rs
@@ -718,11 +718,12 @@ pub fn get_pr_comments(
 
 pub fn get_prs_to_review(
     json: bool,
+    include_teams: bool,
     hostname: Option<&str>,
     config: &Config,
 ) -> anyhow::Result<()> {
     let github_client = github_client_for_hostname_or_current_repo(hostname, config)?;
-    let pull_requests = github_client.get_prs_to_review()?;
+    let pull_requests = github_client.get_prs_to_review(include_teams)?;
 
     if json {
         return print_json(&pull_requests);

--- a/wkfl/src/github.rs
+++ b/wkfl/src/github.rs
@@ -298,14 +298,19 @@ impl GitHubClient {
     }
 
     /// List open pull requests where the authenticated user has a pending review request.
-    pub fn get_prs_to_review(&self) -> Result<Vec<PrToReview>> {
+    pub fn get_prs_to_review(&self, include_teams: bool) -> Result<Vec<PrToReview>> {
         let mut pull_requests = Vec::new();
         let mut cursor: Option<String> = None;
-        let query = "is:pr is:open archived:false review-requested:@me";
+        let review_request_filter = if include_teams {
+            "review-requested:@me"
+        } else {
+            "user-review-requested:@me"
+        };
+        let query = format!("is:pr is:open archived:false {review_request_filter}");
 
         loop {
             let variables = GraphQLPrsToReviewVariables {
-                query,
+                query: &query,
                 cursor: cursor.as_deref(),
             };
 

--- a/wkfl/src/main.rs
+++ b/wkfl/src/main.rs
@@ -177,6 +177,9 @@ enum GithubCommands {
         /// Output matching pull requests as JSON.
         #[arg(long)]
         json: bool,
+        /// Include pull requests requested via team review requests.
+        #[arg(long)]
+        include_teams: bool,
     },
     /// List pull requests associated with a commit.
     #[command(name = "get_pr")]
@@ -473,9 +476,15 @@ fn main() -> Result<(), Box<dyn Error>> {
             hostname,
             command: github_command,
         } => match github_command {
-            GithubCommands::PrsToReview { json } => {
-                actions::get_prs_to_review(json, hostname.as_deref(), &context.config)?
-            }
+            GithubCommands::PrsToReview {
+                json,
+                include_teams,
+            } => actions::get_prs_to_review(
+                json,
+                include_teams,
+                hostname.as_deref(),
+                &context.config,
+            )?,
             GithubCommands::GetPr { commit_sha, json } => actions::get_pull_request_for_commit(
                 commit_sha,
                 json,


### PR DESCRIPTION
I added a flag to also include them if I ever want that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--include-teams` CLI flag to the PRs review command, allowing users to control whether team review requests are included when fetching pending reviews. This provides enhanced filtering capabilities to distinguish between personal and team review requests, enabling more granular workflow management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kdeal/misc/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->