### PR TITLE
Move get_pr to get_pr_for_commit and make get_pr get info about a pr

### DIFF
--- a/wkfl/src/actions.rs
+++ b/wkfl/src/actions.rs
@@ -12,8 +12,8 @@ use crate::config::Config;
 use crate::config::WebChatProvider;
 use crate::git::{self, extract_owner_repo_from_url, extract_repo_from_url};
 use crate::github::{
-    create_github_client, create_github_client_for_host, is_bot_user, IssueComment, Notification,
-    PrComments, PrToReview, ReviewComment,
+    create_github_client, create_github_client_for_host, is_bot_user, GitHubClient, IssueComment,
+    Notification, PrComments, PrToReview, PullRequestDetails, ReviewComment,
 };
 use crate::jira::{create_jira_client, format_jira_date};
 use crate::llm;
@@ -637,24 +637,21 @@ pub fn run_build_commands(_context: &mut Context, list: bool) -> anyhow::Result<
     Ok(())
 }
 
-pub fn get_pull_request_for_commit(
+pub fn get_pr_for_commit(
     commit_sha: Option<String>,
+    repo_slug: Option<&str>,
     json: bool,
     hostname: Option<&str>,
     config: &Config,
 ) -> anyhow::Result<()> {
-    let repo = git::get_repository()?;
-
     let sha = if let Some(sha) = commit_sha {
         sha
     } else {
+        let repo = git::get_repository()?;
         git::get_current_commit_sha(&repo)?
     };
 
-    let remote_url = git::get_default_remote_url(&repo)?;
-    let (owner, repo_name) = extract_owner_repo_from_url(&remote_url)?;
-
-    let github_client = github_client_for_remote(&remote_url, hostname, config)?;
+    let (owner, repo_name, github_client) = github_repo_context(repo_slug, hostname, config)?;
     let pull_requests = github_client.get_pull_requests_for_commit(&owner, &repo_name, &sha)?;
 
     if json {
@@ -677,8 +674,29 @@ pub fn get_pull_request_for_commit(
     Ok(())
 }
 
+pub fn get_pr(
+    pr_number: Option<u64>,
+    repo_slug: Option<&str>,
+    json: bool,
+    hostname: Option<&str>,
+    config: &Config,
+) -> anyhow::Result<()> {
+    let (owner, repo_name, github_client) = github_repo_context(repo_slug, hostname, config)?;
+    let pr_num = resolve_pr_number(pr_number, &github_client, &owner, &repo_name)?;
+
+    let details = github_client.get_pull_request_details(&owner, &repo_name, pr_num)?;
+
+    if json {
+        return print_json(&details);
+    }
+
+    print_pr_details_markdown(&details)
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn get_pr_comments(
     pr_number: Option<u64>,
+    repo_slug: Option<&str>,
     filter_timeline: bool,
     filter_bots: bool,
     filter_diff: bool,
@@ -686,24 +704,9 @@ pub fn get_pr_comments(
     hostname: Option<&str>,
     config: &Config,
 ) -> anyhow::Result<()> {
-    let repo = git::get_repository()?;
-    let remote_url = git::get_default_remote_url(&repo)?;
-    let (owner, repo_name) = extract_owner_repo_from_url(&remote_url)?;
-    let github_client = github_client_for_remote(&remote_url, hostname, config)?;
+    let (owner, repo_name, github_client) = github_repo_context(repo_slug, hostname, config)?;
 
-    let pr_num = if let Some(num) = pr_number {
-        num
-    } else {
-        // Find PR for current commit
-        let sha = git::get_current_commit_sha(&repo)?;
-        let prs = github_client.get_pull_requests_for_commit(&owner, &repo_name, &sha)?;
-
-        if prs.is_empty() {
-            anyhow::bail!("No pull request found for current commit {}", sha);
-        }
-
-        prs[0].number
-    };
+    let pr_num = resolve_pr_number(pr_number, &github_client, &owner, &repo_name)?;
 
     let comments = github_client.get_pr_comments(&owner, &repo_name, pr_num)?;
 
@@ -803,6 +806,45 @@ fn github_client_for_remote(
     }
 }
 
+fn github_repo_context(
+    repo_slug: Option<&str>,
+    hostname: Option<&str>,
+    config: &Config,
+) -> anyhow::Result<(String, String, GitHubClient)> {
+    match (repo_slug, hostname) {
+        (Some(_), None) => anyhow::bail!("--hostname is required when --repo is specified"),
+        (None, Some(_)) => anyhow::bail!("--repo is required when --hostname is specified"),
+        _ => {}
+    }
+
+    if let Some(repo_slug) = repo_slug {
+        let (owner, repo_name) = parse_repo_slug(repo_slug)?;
+        let Some(hostname) = hostname else {
+            unreachable!("repo_slug and hostname combinations are validated above")
+        };
+        let github_client = create_github_client_for_host(hostname, config)?;
+        return Ok((owner, repo_name, github_client));
+    }
+
+    let repo = git::get_repository()?;
+    let remote_url = git::get_default_remote_url(&repo)?;
+    let (owner, repo_name) = extract_owner_repo_from_url(&remote_url)?;
+    let github_client = github_client_for_remote(&remote_url, hostname, config)?;
+    Ok((owner, repo_name, github_client))
+}
+
+fn parse_repo_slug(repo_slug: &str) -> anyhow::Result<(String, String)> {
+    let (owner, repo_name) = repo_slug
+        .split_once('/')
+        .ok_or_else(|| anyhow!("Repository must be specified as owner/name"))?;
+
+    if owner.is_empty() || repo_name.is_empty() || repo_name.contains('/') {
+        anyhow::bail!("Repository must be specified as owner/name");
+    }
+
+    Ok((owner.to_string(), repo_name.to_string()))
+}
+
 fn github_client_for_hostname_or_current_repo(
     hostname: Option<&str>,
     config: &Config,
@@ -826,6 +868,236 @@ fn print_pr_to_review(pr: &PrToReview) {
     println!("URL: {}", pr.url);
 
     println!();
+}
+
+fn resolve_pr_number(
+    pr_number: Option<u64>,
+    github_client: &GitHubClient,
+    owner: &str,
+    repo_name: &str,
+) -> anyhow::Result<u64> {
+    if let Some(num) = pr_number {
+        return Ok(num);
+    }
+
+    let repo = git::get_repository()?;
+    let sha = git::get_current_commit_sha(&repo)?;
+    let prs = github_client.get_pull_requests_for_commit(owner, repo_name, &sha)?;
+
+    if prs.is_empty() {
+        anyhow::bail!("No pull request found for current commit {sha}");
+    }
+
+    Ok(prs[0].number)
+}
+
+fn print_pr_details_markdown(details: &PullRequestDetails) -> anyhow::Result<()> {
+    let pr = &details.pull_request;
+    let number = json_u64(pr, "number").unwrap_or_default();
+    let title = json_str(pr, "title").unwrap_or("(untitled)");
+
+    println!("# PR #{}: {}\n", number, title);
+    print_json_field("URL", pr, "html_url");
+    print_json_field("State", pr, "state");
+    print_json_field("Author", pr.get("user").unwrap_or(pr), "login");
+    print_json_field("Created", pr, "created_at");
+    print_json_field("Updated", pr, "updated_at");
+    print_json_field("Merged", pr, "merged_at");
+
+    if let Some(body) = json_str(pr, "body").filter(|body| !body.trim().is_empty()) {
+        println!("\n## Summary\n");
+        println!("{}\n", body.trim());
+    }
+
+    println!("## Branches\n");
+    println!("- Base: {}", branch_label(pr.get("base")));
+    println!("- Head: {}", branch_label(pr.get("head")));
+
+    println!("\n## Review Metadata\n");
+    println!(
+        "- Changed files: {}",
+        json_u64(pr, "changed_files").unwrap_or(0)
+    );
+    println!("- Additions: {}", json_u64(pr, "additions").unwrap_or(0));
+    println!("- Deletions: {}", json_u64(pr, "deletions").unwrap_or(0));
+    println!("- Commits: {}", details.commits.len());
+    println!("- Reviews: {}", details.reviews.len());
+    println!("- Timeline comments: {}", details.issue_comments.len());
+    println!("- Review comments: {}", details.review_comments.len());
+    println!("- Review threads: {}", details.review_threads.len());
+    println!(
+        "- Unresolved threads: {}",
+        details
+            .review_threads
+            .iter()
+            .filter(|thread| !thread.is_resolved)
+            .count()
+    );
+    println!(
+        "- Requested reviewers: {}",
+        user_list(pr.get("requested_reviewers"))
+    );
+    println!(
+        "- Requested teams: {}",
+        team_list(pr.get("requested_teams"))
+    );
+
+    if let Some(status) = &details.status {
+        println!("\n## Latest Status\n");
+        print_json_field("State", status, "state");
+        print_json_field("Total count", status, "total_count");
+    }
+
+    if let Some(check_runs) = &details.check_runs {
+        println!("\n## Latest Checks\n");
+        if let Some(total) = json_u64(check_runs, "total_count") {
+            println!("Total count: {}", total);
+        }
+        if let Some(runs) = check_runs
+            .get("check_runs")
+            .and_then(|runs| runs.as_array())
+        {
+            for run in runs {
+                let name = json_str(run, "name").unwrap_or("(unnamed)");
+                let status = json_str(run, "status").unwrap_or("unknown");
+                let conclusion = json_str(run, "conclusion").unwrap_or("none");
+                println!("- {}: {} / {}", name, status, conclusion);
+            }
+        }
+    }
+
+    if !details.files.is_empty() {
+        println!("\n## Files\n");
+        for file in &details.files {
+            let filename = json_str(file, "filename").unwrap_or("(unknown)");
+            let status = json_str(file, "status").unwrap_or("unknown");
+            let additions = json_u64(file, "additions").unwrap_or(0);
+            let deletions = json_u64(file, "deletions").unwrap_or(0);
+            println!(
+                "- {} ({}, +{}, -{})",
+                filename, status, additions, deletions
+            );
+        }
+    }
+
+    if !details.commits.is_empty() {
+        println!("\n## Commits\n");
+        for commit in &details.commits {
+            let sha = json_str(commit, "sha").unwrap_or("");
+            let short_sha = sha.get(..7).unwrap_or(sha);
+            let message = commit
+                .get("commit")
+                .and_then(|commit| commit.get("message"))
+                .and_then(|message| message.as_str())
+                .unwrap_or("")
+                .lines()
+                .next()
+                .unwrap_or("");
+            println!("- {} {}", short_sha, message);
+        }
+    }
+
+    if !details.reviews.is_empty() {
+        println!("\n## Reviews\n");
+        for review in &details.reviews {
+            let author = review
+                .get("user")
+                .and_then(|user| json_str(user, "login"))
+                .unwrap_or("unknown");
+            let state = json_str(review, "state").unwrap_or("unknown");
+            let submitted = json_str(review, "submitted_at").unwrap_or("unknown time");
+            println!("- @{}: {} ({})", author, state, submitted);
+        }
+    }
+
+    print_comments_markdown(
+        &PrComments {
+            issue_comments: details.issue_comments.clone(),
+            review_comments: details.review_comments.clone(),
+        },
+        false,
+        false,
+        false,
+    )?;
+
+    println!("\n## Diff\n");
+    println!("```diff");
+    println!("{}", details.diff.trim_end());
+    println!("```");
+
+    Ok(())
+}
+
+fn json_str<'a>(value: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    value.get(key).and_then(|value| value.as_str())
+}
+
+fn json_u64(value: &serde_json::Value, key: &str) -> Option<u64> {
+    value.get(key).and_then(|value| value.as_u64())
+}
+
+fn print_json_field(label: &str, value: &serde_json::Value, key: &str) {
+    if let Some(field) = value.get(key) {
+        if field.is_null() {
+            return;
+        }
+        if let Some(text) = field.as_str() {
+            println!("{}: {}", label, text);
+        } else {
+            println!("{}: {}", label, field);
+        }
+    }
+}
+
+fn branch_label(branch: Option<&serde_json::Value>) -> String {
+    branch
+        .map(|branch| {
+            let label = json_str(branch, "label").unwrap_or("unknown");
+            let sha = json_str(branch, "sha").unwrap_or("");
+            if sha.is_empty() {
+                label.to_string()
+            } else {
+                format!("{} ({})", label, sha)
+            }
+        })
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn user_list(value: Option<&serde_json::Value>) -> String {
+    let users = value
+        .and_then(|value| value.as_array())
+        .map(|users| {
+            users
+                .iter()
+                .filter_map(|user| json_str(user, "login"))
+                .map(|login| format!("@{}", login))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    if users.is_empty() {
+        "none".to_string()
+    } else {
+        users.join(", ")
+    }
+}
+
+fn team_list(value: Option<&serde_json::Value>) -> String {
+    let teams = value
+        .and_then(|value| value.as_array())
+        .map(|teams| {
+            teams
+                .iter()
+                .filter_map(|team| json_str(team, "slug"))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    if teams.is_empty() {
+        "none".to_string()
+    } else {
+        teams.join(", ")
+    }
 }
 
 fn print_notification(notification: &Notification) {

--- a/wkfl/src/github.rs
+++ b/wkfl/src/github.rs
@@ -2,17 +2,28 @@ use crate::config::resolve_secret;
 use crate::config::Config;
 use crate::git::host_from_remote_url;
 use crate::gql_queries;
+use crate::gql_queries::common::{GraphQLAuthor, GraphQLPageInfo};
+use crate::gql_queries::pr_details::{
+    GraphQLCheckRunNode, GraphQLCommitConnection, GraphQLCommitNode, GraphQLFileConnection,
+    GraphQLFileNode, GraphQLIssueCommentConnection, GraphQLIssueCommentNode, GraphQLPrCommentsPage,
+    GraphQLPrCommitsPage, GraphQLPrConnectionPageData, GraphQLPrConnectionVariables,
+    GraphQLPrDetailsData, GraphQLPrDetailsVariables, GraphQLPrFilesPage,
+    GraphQLPrReviewRequestsPage, GraphQLPrReviewThreadsPage, GraphQLPrReviewsPage,
+    GraphQLPullRequest, GraphQLRequestedReviewer, GraphQLReviewConnection, GraphQLReviewNode,
+    GraphQLReviewRequestConnection, GraphQLReviewThreadCommentsData,
+    GraphQLReviewThreadCommentsVariables, GraphQLStatusCommit,
+};
 use crate::gql_queries::prs_to_review::{
     GraphQLPrToReviewNode, GraphQLPrsToReviewData, GraphQLPrsToReviewVariables,
     GraphQLSearchConnection,
 };
 use crate::gql_queries::review_comments::{
-    GraphQLReviewCommentNode, GraphQLReviewCommentsData, GraphQLReviewCommentsVariables,
-    GraphQLReviewThreadConnection, GraphQLReviewThreadNode,
+    GraphQLReviewCommentConnection, GraphQLReviewCommentNode, GraphQLReviewCommentsData,
+    GraphQLReviewCommentsVariables, GraphQLReviewThreadConnection, GraphQLReviewThreadNode,
 };
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{json, Value};
 use url::Url;
 /// A GitHub pull request minimal representation
 #[derive(Debug, Deserialize, Serialize)]
@@ -25,7 +36,7 @@ pub struct PullRequest {
 }
 
 /// A GitHub user
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
     pub login: String,
     #[serde(rename = "type")]
@@ -33,7 +44,7 @@ pub struct User {
 }
 
 /// A GitHub issue/PR comment (timeline comment)
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct IssueComment {
     pub body: String,
     pub user: User,
@@ -41,7 +52,7 @@ pub struct IssueComment {
 }
 
 /// A GitHub pull request review comment (diff comment)
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ReviewComment {
     pub body: String,
     pub user: User,
@@ -59,11 +70,38 @@ pub struct ReviewComment {
     pub is_resolved: Option<bool>,
 }
 
+/// A GitHub pull request review thread.
+#[derive(Debug, Serialize)]
+pub struct ReviewThread {
+    pub id: String,
+    pub is_resolved: bool,
+    pub diff_side: String,
+    pub start_diff_side: Option<String>,
+    pub comments: Vec<ReviewComment>,
+    #[serde(skip)]
+    comments_page_info: GraphQLPageInfo,
+}
+
 /// Container for all PR comment types
 #[derive(Debug, Serialize)]
 pub struct PrComments {
     pub issue_comments: Vec<IssueComment>,
     pub review_comments: Vec<ReviewComment>,
+}
+
+/// Review-oriented pull request details.
+#[derive(Debug, Serialize)]
+pub struct PullRequestDetails {
+    pub pull_request: Value,
+    pub diff: String,
+    pub files: Vec<Value>,
+    pub issue_comments: Vec<IssueComment>,
+    pub review_comments: Vec<ReviewComment>,
+    pub review_threads: Vec<ReviewThread>,
+    pub reviews: Vec<Value>,
+    pub commits: Vec<Value>,
+    pub status: Option<Value>,
+    pub check_runs: Option<Value>,
 }
 
 /// A pull request that is waiting for the authenticated user's review.
@@ -189,6 +227,21 @@ impl GitHubClient {
         Ok(resp)
     }
 
+    fn api_get_with_accept(&self, path_segments: &[&str], accept: &str) -> Result<ureq::Response> {
+        let url = self.api_url(path_segments, &[])?;
+        let resp = self
+            .set_headers(ureq::get(url.as_str()))
+            .set("Accept", accept)
+            .call()
+            .with_context(|| {
+                format!(
+                    "Failed to query GitHub API at path: {}",
+                    path_segments.join("/")
+                )
+            })?;
+        Ok(resp)
+    }
+
     /// Make a PATCH request to the GitHub API without a request body.
     fn api_patch_empty(&self, path_segments: &[&str]) -> Result<ureq::Response> {
         let url = self.api_url(path_segments, &[])?;
@@ -286,10 +339,182 @@ impl GitHubClient {
         Ok(prs)
     }
 
+    /// Fetch details useful when reviewing a pull request.
+    pub fn get_pull_request_details(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+    ) -> Result<PullRequestDetails> {
+        let pr_path = ["repos", owner, repo, "pulls", &pr_number.to_string()];
+        let diff = self
+            .api_get_with_accept(&pr_path, "application/vnd.github.v3.diff")
+            .with_context(|| format!("Failed to query GitHub API for PR #{pr_number} diff"))?
+            .into_string()
+            .with_context(|| "Failed to parse GitHub pull request diff response")?;
+
+        let mut files = Vec::new();
+        let mut issue_comments = Vec::new();
+        let mut review_threads = Vec::new();
+        let mut reviews = Vec::new();
+        let mut commits = Vec::new();
+
+        let variables = GraphQLPrDetailsVariables {
+            owner,
+            name: repo,
+            pr_number: pr_number as i64,
+            file_cursor: None,
+            commit_cursor: None,
+            review_cursor: None,
+            comment_cursor: None,
+            thread_cursor: None,
+            review_requests_cursor: None,
+        };
+
+        let data: GraphQLPrDetailsData = self
+            .graphql_query(gql_queries::pr_details::QUERY, &variables)
+            .with_context(|| {
+                format!("Failed to query GitHub GraphQL API for PR #{pr_number} details")
+            })?;
+        let repository = data.repository.ok_or_else(|| {
+            anyhow!(
+                "Repository '{}/{}' not found when fetching PR details",
+                owner,
+                repo
+            )
+        })?;
+        let mut pr = repository.pull_request.ok_or_else(|| {
+            anyhow!(
+                "Pull request #{} not found in repository '{}/{}'",
+                pr_number,
+                owner,
+                repo
+            )
+        })?;
+
+        let mut review_request_page_info = pr.review_requests.page_info.clone();
+        while review_request_page_info.has_next_page {
+            let Some(cursor) = review_request_page_info.end_cursor.as_deref() else {
+                break;
+            };
+            let page =
+                self.get_pull_request_review_requests_page(owner, repo, pr_number, cursor)?;
+            pr.review_requests.nodes.extend(page.nodes);
+            review_request_page_info = page.page_info;
+        }
+
+        let pull_request = pull_request_value(&pr);
+        let mut status = None;
+        let mut check_runs = None;
+        if let Some(status_commit) = pr
+            .commits_for_status
+            .nodes
+            .into_iter()
+            .flatten()
+            .next()
+            .map(|node| node.commit)
+        {
+            status = status_value(&status_commit);
+            check_runs = Some(check_runs_value(&status_commit));
+        }
+
+        let mut file_page_info = pr.files.page_info;
+        files.extend(pr.files.nodes.into_iter().flatten().map(file_value));
+
+        let mut commit_page_info = pr.commits.page_info;
+        commits.extend(pr.commits.nodes.into_iter().flatten().map(commit_value));
+
+        let mut review_page_info = pr.reviews.page_info;
+        reviews.extend(pr.reviews.nodes.into_iter().flatten().map(review_value));
+
+        let mut comment_page_info = pr.comments.page_info;
+        issue_comments.extend(
+            pr.comments
+                .nodes
+                .into_iter()
+                .flatten()
+                .map(issue_comment_from_node),
+        );
+
+        let mut thread_page_info = pr.review_threads.page_info;
+        review_threads.extend(
+            pr.review_threads
+                .nodes
+                .into_iter()
+                .map(review_thread_from_node),
+        );
+
+        while file_page_info.has_next_page {
+            let Some(cursor) = file_page_info.end_cursor.as_deref() else {
+                break;
+            };
+            let page = self.get_pull_request_files_page(owner, repo, pr_number, cursor)?;
+            files.extend(page.nodes.into_iter().flatten().map(file_value));
+            file_page_info = page.page_info;
+        }
+
+        while commit_page_info.has_next_page {
+            let Some(cursor) = commit_page_info.end_cursor.as_deref() else {
+                break;
+            };
+            let page = self.get_pull_request_commits_page(owner, repo, pr_number, cursor)?;
+            commits.extend(page.nodes.into_iter().flatten().map(commit_value));
+            commit_page_info = page.page_info;
+        }
+
+        while review_page_info.has_next_page {
+            let Some(cursor) = review_page_info.end_cursor.as_deref() else {
+                break;
+            };
+            let page = self.get_pull_request_reviews_page(owner, repo, pr_number, cursor)?;
+            reviews.extend(page.nodes.into_iter().flatten().map(review_value));
+            review_page_info = page.page_info;
+        }
+
+        while comment_page_info.has_next_page {
+            let Some(cursor) = comment_page_info.end_cursor.as_deref() else {
+                break;
+            };
+            let page = self.get_pull_request_comments_page(owner, repo, pr_number, cursor)?;
+            issue_comments.extend(
+                page.nodes
+                    .into_iter()
+                    .flatten()
+                    .map(issue_comment_from_node),
+            );
+            comment_page_info = page.page_info;
+        }
+
+        while thread_page_info.has_next_page {
+            let Some(cursor) = thread_page_info.end_cursor.as_deref() else {
+                break;
+            };
+            let page = self.get_pull_request_review_threads_page(owner, repo, pr_number, cursor)?;
+            review_threads.extend(page.nodes.into_iter().map(review_thread_from_node));
+            thread_page_info = page.page_info;
+        }
+        self.hydrate_review_thread_comments(&mut review_threads)?;
+        let review_comments = flatten_review_threads(&review_threads);
+
+        Ok(PullRequestDetails {
+            pull_request,
+            diff,
+            files,
+            issue_comments,
+            review_comments,
+            review_threads,
+            reviews,
+            commits,
+            status,
+            check_runs,
+        })
+    }
+
     /// Get all comments for a pull request
     pub fn get_pr_comments(&self, owner: &str, repo: &str, pr_number: u64) -> Result<PrComments> {
         let issue_comments = self.get_issue_comments(owner, repo, pr_number)?;
-        let review_comments = self.get_review_comments(owner, repo, pr_number)?;
+        let review_comments =
+            flatten_review_threads(&self.get_review_threads(owner, repo, pr_number)?);
 
         Ok(PrComments {
             issue_comments,
@@ -341,31 +566,48 @@ impl GitHubClient {
         repo: &str,
         pr_number: u64,
     ) -> Result<Vec<IssueComment>> {
-        let resp = self
-            .api_get(&[
-                "repos",
-                owner,
-                repo,
-                "issues",
-                &pr_number.to_string(),
-                "comments",
-            ])
-            .with_context(|| format!("Failed to query GitHub API for PR #{pr_number} comments"))?;
+        let mut comments = Vec::new();
+        let mut page = 1;
 
-        let comments: Vec<IssueComment> = resp
-            .into_json()
-            .with_context(|| "Failed to parse GitHub issue comments response as JSON")?;
+        loop {
+            let resp = self
+                .api_get_with_query(
+                    &[
+                        "repos",
+                        owner,
+                        repo,
+                        "issues",
+                        &pr_number.to_string(),
+                        "comments",
+                    ],
+                    &[("per_page", "100".to_string()), ("page", page.to_string())],
+                )
+                .with_context(|| {
+                    format!("Failed to query GitHub API for PR #{pr_number} comments")
+                })?;
+            let has_next_page = link_header_has_next(resp.header("link"));
+            let mut page_comments: Vec<IssueComment> = resp
+                .into_json()
+                .with_context(|| "Failed to parse GitHub issue comments response as JSON")?;
+            comments.append(&mut page_comments);
+
+            if !has_next_page {
+                break;
+            }
+            page += 1;
+        }
+
         Ok(comments)
     }
 
-    /// Get review/diff comments for a PR
-    fn get_review_comments(
+    /// Get review/diff threads for a PR
+    fn get_review_threads(
         &self,
         owner: &str,
         repo: &str,
         pr_number: u64,
-    ) -> Result<Vec<ReviewComment>> {
-        let mut all_comments = Vec::new();
+    ) -> Result<Vec<ReviewThread>> {
+        let mut all_threads = Vec::new();
         let mut cursor: Option<String> = None;
 
         loop {
@@ -402,16 +644,9 @@ impl GitHubClient {
 
             let GraphQLReviewThreadConnection { nodes, page_info } = pull_request.review_threads;
             for thread in nodes {
-                let GraphQLReviewThreadNode {
-                    is_resolved,
-                    diff_side,
-                    start_diff_side,
-                    comments,
-                } = thread;
-
-                all_comments.extend(comments.nodes.into_iter().map(|comment| {
-                    review_comment_from_node(comment, &diff_side, &start_diff_side, is_resolved)
-                }));
+                let mut thread = review_thread_from_node(thread);
+                self.hydrate_review_thread_comments(std::slice::from_mut(&mut thread))?;
+                all_threads.push(thread);
             }
 
             if page_info.has_next_page {
@@ -424,7 +659,163 @@ impl GitHubClient {
             }
         }
 
-        Ok(all_comments)
+        Ok(all_threads)
+    }
+
+    fn get_pull_request_files_page(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        cursor: &str,
+    ) -> Result<GraphQLFileConnection> {
+        let variables = pr_connection_variables(owner, repo, pr_number, cursor);
+        let data: GraphQLPrConnectionPageData<GraphQLPrFilesPage> = self
+            .graphql_query(gql_queries::pr_details::FILES_QUERY, &variables)
+            .with_context(|| {
+                format!("Failed to query GitHub GraphQL API for PR #{pr_number} files")
+            })?;
+
+        Ok(pull_request_connection_page(data, owner, repo, pr_number, "files")?.files)
+    }
+
+    fn get_pull_request_commits_page(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        cursor: &str,
+    ) -> Result<GraphQLCommitConnection> {
+        let variables = pr_connection_variables(owner, repo, pr_number, cursor);
+        let data: GraphQLPrConnectionPageData<GraphQLPrCommitsPage> = self
+            .graphql_query(gql_queries::pr_details::COMMITS_QUERY, &variables)
+            .with_context(|| {
+                format!("Failed to query GitHub GraphQL API for PR #{pr_number} commits")
+            })?;
+
+        Ok(pull_request_connection_page(data, owner, repo, pr_number, "commits")?.commits)
+    }
+
+    fn get_pull_request_reviews_page(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        cursor: &str,
+    ) -> Result<GraphQLReviewConnection> {
+        let variables = pr_connection_variables(owner, repo, pr_number, cursor);
+        let data: GraphQLPrConnectionPageData<GraphQLPrReviewsPage> = self
+            .graphql_query(gql_queries::pr_details::REVIEWS_QUERY, &variables)
+            .with_context(|| {
+                format!("Failed to query GitHub GraphQL API for PR #{pr_number} reviews")
+            })?;
+
+        Ok(pull_request_connection_page(data, owner, repo, pr_number, "reviews")?.reviews)
+    }
+
+    fn get_pull_request_comments_page(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        cursor: &str,
+    ) -> Result<GraphQLIssueCommentConnection> {
+        let variables = pr_connection_variables(owner, repo, pr_number, cursor);
+        let data: GraphQLPrConnectionPageData<GraphQLPrCommentsPage> = self
+            .graphql_query(gql_queries::pr_details::COMMENTS_QUERY, &variables)
+            .with_context(|| {
+                format!("Failed to query GitHub GraphQL API for PR #{pr_number} comments")
+            })?;
+
+        Ok(pull_request_connection_page(data, owner, repo, pr_number, "comments")?.comments)
+    }
+
+    fn get_pull_request_review_threads_page(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        cursor: &str,
+    ) -> Result<crate::gql_queries::pr_details::GraphQLReviewThreadConnection> {
+        let variables = pr_connection_variables(owner, repo, pr_number, cursor);
+        let data: GraphQLPrConnectionPageData<GraphQLPrReviewThreadsPage> = self
+            .graphql_query(gql_queries::pr_details::REVIEW_THREADS_QUERY, &variables)
+            .with_context(|| {
+                format!("Failed to query GitHub GraphQL API for PR #{pr_number} review threads")
+            })?;
+
+        Ok(
+            pull_request_connection_page(data, owner, repo, pr_number, "review threads")?
+                .review_threads,
+        )
+    }
+
+    fn get_pull_request_review_requests_page(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        cursor: &str,
+    ) -> Result<GraphQLReviewRequestConnection> {
+        let variables = pr_connection_variables(owner, repo, pr_number, cursor);
+        let data: GraphQLPrConnectionPageData<GraphQLPrReviewRequestsPage> = self
+            .graphql_query(gql_queries::pr_details::REVIEW_REQUESTS_QUERY, &variables)
+            .with_context(|| {
+                format!("Failed to query GitHub GraphQL API for PR #{pr_number} review requests")
+            })?;
+
+        Ok(
+            pull_request_connection_page(data, owner, repo, pr_number, "review requests")?
+                .review_requests,
+        )
+    }
+
+    fn get_review_thread_comments_page(
+        &self,
+        thread_id: &str,
+        cursor: &str,
+    ) -> Result<crate::gql_queries::review_comments::GraphQLReviewCommentConnection> {
+        let variables = GraphQLReviewThreadCommentsVariables {
+            thread_id,
+            cursor: Some(cursor),
+        };
+        let data: GraphQLReviewThreadCommentsData = self
+            .graphql_query(
+                gql_queries::pr_details::REVIEW_THREAD_COMMENTS_QUERY,
+                &variables,
+            )
+            .with_context(|| {
+                format!("Failed to query GitHub GraphQL API for review thread {thread_id} comments")
+            })?;
+
+        Ok(data
+            .node
+            .ok_or_else(|| anyhow!("Review thread '{thread_id}' not found"))?
+            .comments)
+    }
+
+    fn hydrate_review_thread_comments(&self, threads: &mut [ReviewThread]) -> Result<()> {
+        for thread in threads {
+            while thread.comments_page_info.has_next_page {
+                let Some(cursor) = thread.comments_page_info.end_cursor.as_deref() else {
+                    break;
+                };
+                let page = self.get_review_thread_comments_page(&thread.id, cursor)?;
+                thread
+                    .comments
+                    .extend(page.nodes.into_iter().map(|comment| {
+                        review_comment_from_node(
+                            comment,
+                            &thread.diff_side,
+                            &thread.start_diff_side,
+                            thread.is_resolved,
+                        )
+                    }));
+                thread.comments_page_info = page.page_info;
+            }
+        }
+
+        Ok(())
     }
 
     fn graphql_query<T, V>(&self, query: &str, variables: &V) -> Result<T>
@@ -466,6 +857,47 @@ fn link_header_has_next(link_header: Option<&str>) -> bool {
         .unwrap_or(false)
 }
 
+fn pr_connection_variables<'a>(
+    owner: &'a str,
+    repo: &'a str,
+    pr_number: u64,
+    cursor: &'a str,
+) -> GraphQLPrConnectionVariables<'a> {
+    GraphQLPrConnectionVariables {
+        owner,
+        name: repo,
+        pr_number: pr_number as i64,
+        cursor: Some(cursor),
+    }
+}
+
+fn pull_request_connection_page<T>(
+    data: GraphQLPrConnectionPageData<T>,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    connection_name: &str,
+) -> Result<T> {
+    let repository = data.repository.ok_or_else(|| {
+        anyhow!(
+            "Repository '{}/{}' not found when fetching PR {}",
+            owner,
+            repo,
+            connection_name
+        )
+    })?;
+
+    repository.pull_request.ok_or_else(|| {
+        anyhow!(
+            "Pull request #{} not found in repository '{}/{}' when fetching {}",
+            pr_number,
+            owner,
+            repo,
+            connection_name
+        )
+    })
+}
+
 fn review_comment_from_node(
     node: GraphQLReviewCommentNode,
     diff_side: &str,
@@ -504,6 +936,204 @@ fn review_comment_from_node(
         start_side: start_diff_side.clone(),
         is_resolved: Some(is_resolved),
     }
+}
+
+fn review_thread_from_node(node: GraphQLReviewThreadNode) -> ReviewThread {
+    let GraphQLReviewThreadNode {
+        id,
+        is_resolved,
+        diff_side,
+        start_diff_side,
+        comments,
+    } = node;
+    let GraphQLReviewCommentConnection { nodes, page_info } = comments;
+
+    ReviewThread {
+        id,
+        is_resolved,
+        diff_side: diff_side.clone(),
+        start_diff_side: start_diff_side.clone(),
+        comments_page_info: page_info,
+        comments: nodes
+            .into_iter()
+            .map(|comment| {
+                review_comment_from_node(comment, &diff_side, &start_diff_side, is_resolved)
+            })
+            .collect(),
+    }
+}
+
+fn flatten_review_threads(threads: &[ReviewThread]) -> Vec<ReviewComment> {
+    threads
+        .iter()
+        .flat_map(|thread| {
+            thread.comments.iter().map(|comment| ReviewComment {
+                body: comment.body.clone(),
+                user: User {
+                    login: comment.user.login.clone(),
+                    user_type: comment.user.user_type.clone(),
+                },
+                created_at: comment.created_at.clone(),
+                path: comment.path.clone(),
+                original_line: comment.original_line,
+                original_start_line: comment.original_start_line,
+                diff_hunk: comment.diff_hunk.clone(),
+                side: comment.side.clone(),
+                start_side: comment.start_side.clone(),
+                is_resolved: comment.is_resolved,
+            })
+        })
+        .collect()
+}
+
+fn graphql_author_to_user(author: Option<GraphQLAuthor>) -> User {
+    author
+        .map(|author| User {
+            login: author.login,
+            user_type: author.typename,
+        })
+        .unwrap_or_else(|| User {
+            login: "unknown".to_string(),
+            user_type: "Unknown".to_string(),
+        })
+}
+
+fn pull_request_value(pr: &GraphQLPullRequest) -> Value {
+    let requested_reviewers: Vec<Value> = pr
+        .review_requests
+        .nodes
+        .iter()
+        .filter_map(|node| node.as_ref())
+        .filter_map(|node| node.requested_reviewer.as_ref())
+        .filter(|reviewer| reviewer.typename == "User")
+        .filter_map(requested_user_value)
+        .collect();
+    let requested_teams: Vec<Value> = pr
+        .review_requests
+        .nodes
+        .iter()
+        .filter_map(|node| node.as_ref())
+        .filter_map(|node| node.requested_reviewer.as_ref())
+        .filter(|reviewer| reviewer.typename == "Team")
+        .filter_map(requested_team_value)
+        .collect();
+    let head_repo = pr.head_repository.as_ref().unwrap_or(&pr.base_repository);
+
+    json!({
+        "number": pr.number,
+        "title": pr.title,
+        "html_url": pr.url,
+        "state": pr.state.to_lowercase(),
+        "body": pr.body,
+        "created_at": pr.created_at,
+        "updated_at": pr.updated_at,
+        "merged_at": pr.merged_at,
+        "additions": pr.additions,
+        "deletions": pr.deletions,
+        "changed_files": pr.changed_files,
+        "user": graphql_author_to_user(pr.author.clone()),
+        "base": {
+            "label": format!("{}:{}", pr.base_repository.name_with_owner, pr.base_ref_name),
+            "sha": pr.base_ref_oid,
+        },
+        "head": {
+            "label": format!("{}:{}", head_repo.name_with_owner, pr.head_ref_name),
+            "sha": pr.head_ref_oid,
+        },
+        "requested_reviewers": requested_reviewers,
+        "requested_teams": requested_teams,
+    })
+}
+
+fn requested_user_value(reviewer: &GraphQLRequestedReviewer) -> Option<Value> {
+    Some(json!({
+        "login": reviewer.login.as_ref()?,
+        "type": reviewer.typename,
+    }))
+}
+
+fn requested_team_value(reviewer: &GraphQLRequestedReviewer) -> Option<Value> {
+    Some(json!({
+        "name": reviewer.name.as_ref()?,
+        "slug": reviewer.slug.as_ref()?,
+    }))
+}
+
+fn file_value(file: GraphQLFileNode) -> Value {
+    json!({
+        "filename": file.path,
+        "status": file.change_type.to_lowercase(),
+        "additions": file.additions,
+        "deletions": file.deletions,
+    })
+}
+
+fn commit_value(commit: GraphQLCommitNode) -> Value {
+    json!({
+        "sha": commit.commit.oid,
+        "commit": {
+            "message": commit.commit.message,
+        },
+    })
+}
+
+fn review_value(review: GraphQLReviewNode) -> Value {
+    json!({
+        "user": graphql_author_to_user(review.author),
+        "state": review.state,
+        "submitted_at": review.submitted_at,
+    })
+}
+
+fn issue_comment_from_node(comment: GraphQLIssueCommentNode) -> IssueComment {
+    IssueComment {
+        body: comment.body,
+        user: graphql_author_to_user(comment.author),
+        created_at: comment.created_at,
+    }
+}
+
+fn status_value(commit: &GraphQLStatusCommit) -> Option<Value> {
+    commit.status.as_ref().map(|status| {
+        json!({
+            "sha": commit.oid,
+            "state": status.state.to_lowercase(),
+            "total_count": status.contexts.len(),
+        })
+    })
+}
+
+fn check_runs_value(commit: &GraphQLStatusCommit) -> Value {
+    let Some(rollup) = &commit.status_check_rollup else {
+        return json!({
+            "total_count": 0,
+            "check_runs": [],
+        });
+    };
+
+    let check_runs: Vec<Value> = commit
+        .status_check_rollup
+        .as_ref()
+        .map(|rollup| &rollup.contexts)
+        .into_iter()
+        .flat_map(|contexts| contexts.nodes.iter())
+        .filter_map(|node| node.as_ref())
+        .filter(|node| node.typename == "CheckRun")
+        .map(check_run_value)
+        .collect();
+
+    json!({
+        "total_count": rollup.contexts.total_count,
+        "check_runs": check_runs,
+    })
+}
+
+fn check_run_value(run: &GraphQLCheckRunNode) -> Value {
+    json!({
+        "name": run.name.as_deref().unwrap_or("(unnamed)"),
+        "status": run.status.as_ref().map(|status| status.to_lowercase()).unwrap_or_else(|| "unknown".to_string()),
+        "conclusion": run.conclusion.as_ref().map(|conclusion| conclusion.to_lowercase()),
+    })
 }
 
 impl From<GraphQLPrToReviewNode> for PrToReview {

--- a/wkfl/src/gql_queries.rs
+++ b/wkfl/src/gql_queries.rs
@@ -1,3 +1,4 @@
 pub mod common;
+pub mod pr_details;
 pub mod prs_to_review;
 pub mod review_comments;

--- a/wkfl/src/gql_queries/common.rs
+++ b/wkfl/src/gql_queries/common.rs
@@ -11,7 +11,7 @@ pub struct GraphQLError {
     pub message: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct GraphQLPageInfo {
     #[serde(rename = "hasNextPage")]
     pub has_next_page: bool,
@@ -19,7 +19,7 @@ pub struct GraphQLPageInfo {
     pub end_cursor: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct GraphQLAuthor {
     pub login: String,
     #[serde(rename = "__typename")]

--- a/wkfl/src/gql_queries/pr_details.graphql
+++ b/wkfl/src/gql_queries/pr_details.graphql
@@ -1,0 +1,167 @@
+query PrDetails(
+    $owner: String!,
+    $name: String!,
+    $prNumber: Int!,
+    $fileCursor: String,
+    $commitCursor: String,
+    $reviewCursor: String,
+    $commentCursor: String,
+    $threadCursor: String,
+    $reviewRequestsCursor: String
+) {
+    repository(owner: $owner, name: $name) {
+        pullRequest(number: $prNumber) {
+            number
+            title
+            url
+            state
+            body
+            createdAt
+            updatedAt
+            mergedAt
+            additions
+            deletions
+            changedFiles
+            author {
+                login
+                __typename
+            }
+            baseRefName
+            baseRefOid
+            headRefName
+            headRefOid
+            baseRepository {
+                nameWithOwner
+            }
+            headRepository {
+                nameWithOwner
+            }
+            reviewRequests(first: 100, after: $reviewRequestsCursor) {
+                nodes {
+                    requestedReviewer {
+                        __typename
+                        ... on User {
+                            login
+                        }
+                        ... on Team {
+                            name
+                            slug
+                        }
+                    }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+            files(first: 100, after: $fileCursor) {
+                nodes {
+                    path
+                    additions
+                    deletions
+                    changeType
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+            commits(first: 100, after: $commitCursor) {
+                nodes {
+                    commit {
+                        oid
+                        message
+                    }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+            reviews(first: 100, after: $reviewCursor) {
+                nodes {
+                    author {
+                        login
+                        __typename
+                    }
+                    state
+                    submittedAt
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+            comments(first: 100, after: $commentCursor) {
+                nodes {
+                    body
+                    author {
+                        login
+                        __typename
+                    }
+                    createdAt
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+            reviewThreads(first: 100, after: $threadCursor) {
+                nodes {
+                    id
+                    isResolved
+                    diffSide
+                    startDiffSide
+                    comments(first: 100) {
+                        nodes {
+                            body
+                            author {
+                                login
+                                __typename
+                            }
+                            createdAt
+                            path
+                            originalLine
+                            originalStartLine
+                            diffHunk
+                        }
+                        pageInfo {
+                            hasNextPage
+                            endCursor
+                        }
+                    }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+            commitsForStatus: commits(last: 1) {
+                nodes {
+                    commit {
+                        oid
+                        status {
+                            state
+                            contexts {
+                                state
+                            }
+                        }
+                        statusCheckRollup {
+                            contexts(first: 100) {
+                                totalCount
+                                nodes {
+                                    __typename
+                                    ... on CheckRun {
+                                        name
+                                        status
+                                        conclusion
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/wkfl/src/gql_queries/pr_details.rs
+++ b/wkfl/src/gql_queries/pr_details.rs
@@ -1,0 +1,298 @@
+use super::common::{GraphQLAuthor, GraphQLPageInfo};
+use serde::{Deserialize, Serialize};
+
+pub const QUERY: &str = include_str!("pr_details.graphql");
+pub const FILES_QUERY: &str = include_str!("pr_details_files.graphql");
+pub const COMMITS_QUERY: &str = include_str!("pr_details_commits.graphql");
+pub const REVIEWS_QUERY: &str = include_str!("pr_details_reviews.graphql");
+pub const COMMENTS_QUERY: &str = include_str!("pr_details_comments.graphql");
+pub const REVIEW_THREADS_QUERY: &str = include_str!("pr_details_review_threads.graphql");
+pub const REVIEW_REQUESTS_QUERY: &str = include_str!("pr_details_review_requests.graphql");
+pub const REVIEW_THREAD_COMMENTS_QUERY: &str =
+    include_str!("pr_details_review_thread_comments.graphql");
+
+#[derive(Debug, Serialize)]
+pub struct GraphQLPrDetailsVariables<'a> {
+    pub owner: &'a str,
+    pub name: &'a str,
+    #[serde(rename = "prNumber")]
+    pub pr_number: i64,
+    #[serde(rename = "fileCursor")]
+    pub file_cursor: Option<&'a str>,
+    #[serde(rename = "commitCursor")]
+    pub commit_cursor: Option<&'a str>,
+    #[serde(rename = "reviewCursor")]
+    pub review_cursor: Option<&'a str>,
+    #[serde(rename = "commentCursor")]
+    pub comment_cursor: Option<&'a str>,
+    #[serde(rename = "threadCursor")]
+    pub thread_cursor: Option<&'a str>,
+    #[serde(rename = "reviewRequestsCursor")]
+    pub review_requests_cursor: Option<&'a str>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GraphQLPrConnectionVariables<'a> {
+    pub owner: &'a str,
+    pub name: &'a str,
+    #[serde(rename = "prNumber")]
+    pub pr_number: i64,
+    pub cursor: Option<&'a str>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLPrDetailsData {
+    pub repository: Option<GraphQLRepository>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLPrConnectionPageData<T> {
+    pub repository: Option<GraphQLConnectionPageRepository<T>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLConnectionPageRepository<T> {
+    #[serde(rename = "pullRequest")]
+    pub pull_request: Option<T>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLPrFilesPage {
+    pub files: GraphQLFileConnection,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLPrCommitsPage {
+    pub commits: GraphQLCommitConnection,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLPrReviewsPage {
+    pub reviews: GraphQLReviewConnection,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLPrCommentsPage {
+    pub comments: GraphQLIssueCommentConnection,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLPrReviewThreadsPage {
+    #[serde(rename = "reviewThreads")]
+    pub review_threads: GraphQLReviewThreadConnection,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLPrReviewRequestsPage {
+    #[serde(rename = "reviewRequests")]
+    pub review_requests: GraphQLReviewRequestConnection,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GraphQLReviewThreadCommentsVariables<'a> {
+    #[serde(rename = "threadId")]
+    pub thread_id: &'a str,
+    pub cursor: Option<&'a str>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLReviewThreadCommentsData {
+    pub node: Option<GraphQLReviewThreadCommentsNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLReviewThreadCommentsNode {
+    pub comments: super::review_comments::GraphQLReviewCommentConnection,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLRepository {
+    #[serde(rename = "pullRequest")]
+    pub pull_request: Option<GraphQLPullRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLPullRequest {
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub state: String,
+    pub body: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+    #[serde(rename = "mergedAt")]
+    pub merged_at: Option<String>,
+    pub additions: u64,
+    pub deletions: u64,
+    #[serde(rename = "changedFiles")]
+    pub changed_files: u64,
+    pub author: Option<GraphQLAuthor>,
+    #[serde(rename = "baseRefName")]
+    pub base_ref_name: String,
+    #[serde(rename = "baseRefOid")]
+    pub base_ref_oid: String,
+    #[serde(rename = "headRefName")]
+    pub head_ref_name: String,
+    #[serde(rename = "headRefOid")]
+    pub head_ref_oid: String,
+    #[serde(rename = "baseRepository")]
+    pub base_repository: GraphQLPrRepository,
+    #[serde(rename = "headRepository")]
+    pub head_repository: Option<GraphQLPrRepository>,
+    #[serde(rename = "reviewRequests")]
+    pub review_requests: GraphQLReviewRequestConnection,
+    pub files: GraphQLFileConnection,
+    pub commits: GraphQLCommitConnection,
+    pub reviews: GraphQLReviewConnection,
+    pub comments: GraphQLIssueCommentConnection,
+    #[serde(rename = "reviewThreads")]
+    pub review_threads: GraphQLReviewThreadConnection,
+    #[serde(rename = "commitsForStatus")]
+    pub commits_for_status: GraphQLStatusCommitConnection,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLPrRepository {
+    #[serde(rename = "nameWithOwner")]
+    pub name_with_owner: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLReviewRequestConnection {
+    pub nodes: Vec<Option<GraphQLReviewRequestNode>>,
+    #[serde(rename = "pageInfo")]
+    pub page_info: GraphQLPageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLReviewRequestNode {
+    #[serde(rename = "requestedReviewer")]
+    pub requested_reviewer: Option<GraphQLRequestedReviewer>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLRequestedReviewer {
+    #[serde(rename = "__typename")]
+    pub typename: String,
+    pub login: Option<String>,
+    pub name: Option<String>,
+    pub slug: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLFileConnection {
+    pub nodes: Vec<Option<GraphQLFileNode>>,
+    #[serde(rename = "pageInfo")]
+    pub page_info: GraphQLPageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLFileNode {
+    pub path: String,
+    pub additions: u64,
+    pub deletions: u64,
+    #[serde(rename = "changeType")]
+    pub change_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLCommitConnection {
+    pub nodes: Vec<Option<GraphQLCommitNode>>,
+    #[serde(rename = "pageInfo")]
+    pub page_info: GraphQLPageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLCommitNode {
+    pub commit: GraphQLCommit,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLCommit {
+    pub oid: String,
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLReviewConnection {
+    pub nodes: Vec<Option<GraphQLReviewNode>>,
+    #[serde(rename = "pageInfo")]
+    pub page_info: GraphQLPageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLReviewNode {
+    pub author: Option<GraphQLAuthor>,
+    pub state: String,
+    #[serde(rename = "submittedAt")]
+    pub submitted_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLIssueCommentConnection {
+    pub nodes: Vec<Option<GraphQLIssueCommentNode>>,
+    #[serde(rename = "pageInfo")]
+    pub page_info: GraphQLPageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLIssueCommentNode {
+    pub body: String,
+    pub author: Option<GraphQLAuthor>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLReviewThreadConnection {
+    pub nodes: Vec<super::review_comments::GraphQLReviewThreadNode>,
+    #[serde(rename = "pageInfo")]
+    pub page_info: GraphQLPageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLStatusCommitConnection {
+    pub nodes: Vec<Option<GraphQLStatusCommitNode>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLStatusCommitNode {
+    pub commit: GraphQLStatusCommit,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLStatusCommit {
+    pub oid: String,
+    pub status: Option<GraphQLStatus>,
+    #[serde(rename = "statusCheckRollup")]
+    pub status_check_rollup: Option<GraphQLStatusCheckRollup>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLStatus {
+    pub state: String,
+    pub contexts: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLStatusCheckRollup {
+    pub contexts: GraphQLCheckRunConnection,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLCheckRunConnection {
+    #[serde(rename = "totalCount")]
+    pub total_count: u64,
+    pub nodes: Vec<Option<GraphQLCheckRunNode>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLCheckRunNode {
+    #[serde(rename = "__typename")]
+    pub typename: String,
+    pub name: Option<String>,
+    pub status: Option<String>,
+    pub conclusion: Option<String>,
+}

--- a/wkfl/src/gql_queries/pr_details_comments.graphql
+++ b/wkfl/src/gql_queries/pr_details_comments.graphql
@@ -1,0 +1,20 @@
+query PrDetailsComments($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+        pullRequest(number: $prNumber) {
+            comments(first: 100, after: $cursor) {
+                nodes {
+                    body
+                    author {
+                        login
+                        __typename
+                    }
+                    createdAt
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+        }
+    }
+}

--- a/wkfl/src/gql_queries/pr_details_commits.graphql
+++ b/wkfl/src/gql_queries/pr_details_commits.graphql
@@ -1,0 +1,18 @@
+query PrDetailsCommits($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+        pullRequest(number: $prNumber) {
+            commits(first: 100, after: $cursor) {
+                nodes {
+                    commit {
+                        oid
+                        message
+                    }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+        }
+    }
+}

--- a/wkfl/src/gql_queries/pr_details_files.graphql
+++ b/wkfl/src/gql_queries/pr_details_files.graphql
@@ -1,0 +1,18 @@
+query PrDetailsFiles($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+        pullRequest(number: $prNumber) {
+            files(first: 100, after: $cursor) {
+                nodes {
+                    path
+                    additions
+                    deletions
+                    changeType
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+        }
+    }
+}

--- a/wkfl/src/gql_queries/pr_details_review_requests.graphql
+++ b/wkfl/src/gql_queries/pr_details_review_requests.graphql
@@ -1,0 +1,24 @@
+query PrDetailsReviewRequests($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+        pullRequest(number: $prNumber) {
+            reviewRequests(first: 100, after: $cursor) {
+                nodes {
+                    requestedReviewer {
+                        __typename
+                        ... on User {
+                            login
+                        }
+                        ... on Team {
+                            name
+                            slug
+                        }
+                    }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+        }
+    }
+}

--- a/wkfl/src/gql_queries/pr_details_review_thread_comments.graphql
+++ b/wkfl/src/gql_queries/pr_details_review_thread_comments.graphql
@@ -1,0 +1,24 @@
+query PrDetailsReviewThreadComments($threadId: ID!, $cursor: String) {
+    node(id: $threadId) {
+        ... on PullRequestReviewThread {
+            comments(first: 100, after: $cursor) {
+                nodes {
+                    body
+                    author {
+                        login
+                        __typename
+                    }
+                    createdAt
+                    path
+                    originalLine
+                    originalStartLine
+                    diffHunk
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+        }
+    }
+}

--- a/wkfl/src/gql_queries/pr_details_review_threads.graphql
+++ b/wkfl/src/gql_queries/pr_details_review_threads.graphql
@@ -1,4 +1,4 @@
-query ReviewComments($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+query PrDetailsReviewThreads($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
     repository(owner: $owner, name: $name) {
         pullRequest(number: $prNumber) {
             reviewThreads(first: 100, after: $cursor) {

--- a/wkfl/src/gql_queries/pr_details_reviews.graphql
+++ b/wkfl/src/gql_queries/pr_details_reviews.graphql
@@ -1,0 +1,20 @@
+query PrDetailsReviews($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+        pullRequest(number: $prNumber) {
+            reviews(first: 100, after: $cursor) {
+                nodes {
+                    author {
+                        login
+                        __typename
+                    }
+                    state
+                    submittedAt
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+        }
+    }
+}

--- a/wkfl/src/gql_queries/review_comments.rs
+++ b/wkfl/src/gql_queries/review_comments.rs
@@ -38,6 +38,7 @@ pub struct GraphQLReviewThreadConnection {
 
 #[derive(Debug, Deserialize)]
 pub struct GraphQLReviewThreadNode {
+    pub id: String,
     #[serde(rename = "isResolved")]
     pub is_resolved: bool,
     #[serde(rename = "diffSide")]
@@ -50,6 +51,8 @@ pub struct GraphQLReviewThreadNode {
 #[derive(Debug, Deserialize)]
 pub struct GraphQLReviewCommentConnection {
     pub nodes: Vec<GraphQLReviewCommentNode>,
+    #[serde(rename = "pageInfo")]
+    pub page_info: GraphQLPageInfo,
 }
 
 #[derive(Debug, Deserialize)]

--- a/wkfl/src/main.rs
+++ b/wkfl/src/main.rs
@@ -181,12 +181,28 @@ enum GithubCommands {
         #[arg(long)]
         include_teams: bool,
     },
-    /// List pull requests associated with a commit.
+    /// Fetch information about a pull request for review.
     #[command(name = "get_pr")]
     GetPr {
+        /// Pull request number to inspect (defaults to the current commit's PR).
+        #[arg(value_hint = ValueHint::Other)]
+        pr_number: Option<u64>,
+        /// Repository to inspect as owner/name (defaults to the current repository).
+        #[arg(long, value_hint = ValueHint::Other)]
+        repo: Option<String>,
+        /// Output pull request information as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// List pull requests associated with a commit.
+    #[command(name = "get_pr_for_commit")]
+    GetPrForCommit {
         /// Commit SHA to inspect (defaults to the current HEAD).
         #[arg(value_hint = ValueHint::Other)]
         commit_sha: Option<String>,
+        /// Repository to inspect as owner/name (defaults to the current repository).
+        #[arg(long, value_hint = ValueHint::Other)]
+        repo: Option<String>,
         /// Output matching pull requests as JSON.
         #[arg(long)]
         json: bool,
@@ -197,6 +213,9 @@ enum GithubCommands {
         /// Pull request number to inspect (defaults to the current commit's PR).
         #[arg(value_hint = ValueHint::Other)]
         pr_number: Option<u64>,
+        /// Repository to inspect as owner/name (defaults to the current repository).
+        #[arg(long, value_hint = ValueHint::Other)]
+        repo: Option<String>,
         /// Exclude general timeline comments from the output.
         #[arg(long)]
         filter_timeline: bool,
@@ -485,20 +504,38 @@ fn main() -> Result<(), Box<dyn Error>> {
                 hostname.as_deref(),
                 &context.config,
             )?,
-            GithubCommands::GetPr { commit_sha, json } => actions::get_pull_request_for_commit(
+            GithubCommands::GetPr {
+                pr_number,
+                repo,
+                json,
+            } => actions::get_pr(
+                pr_number,
+                repo.as_deref(),
+                json,
+                hostname.as_deref(),
+                &context.config,
+            )?,
+            GithubCommands::GetPrForCommit {
                 commit_sha,
+                repo,
+                json,
+            } => actions::get_pr_for_commit(
+                commit_sha,
+                repo.as_deref(),
                 json,
                 hostname.as_deref(),
                 &context.config,
             )?,
             GithubCommands::GetPrComments {
                 pr_number,
+                repo,
                 filter_timeline,
                 no_filter_bots,
                 filter_diff,
                 json,
             } => actions::get_pr_comments(
                 pr_number,
+                repo.as_deref(),
                 filter_timeline,
                 !no_filter_bots,
                 filter_diff,


### PR DESCRIPTION
That was poor naming on my part initially, but we got there eventually.

The get_pr command now fetches most of the information you would need about a pull request to know its current state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pull request details now include comprehensive metadata: reviews, review threads, file changes, commits, and status checks.
  * Enhanced repository argument support across PR-related commands.

* **Bug Fixes**
  * Improved consistency in repository argument handling for PR retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->