### PR TITLE
Publish a non-ssh entrypoint version of devenv for codespaces

### DIFF
--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -10,6 +10,13 @@ on:
 jobs:
   build_and_push:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: devenv-cs
+            image: devenv-cs
+          - target: devenv-ssh
+            image: devenv
     permissions:
       packages: write
     steps:
@@ -27,7 +34,8 @@ jobs:
       uses: docker/build-push-action@v7
       with:
         context: "{{defaultContext}}:devenv"
+        target: ${{ matrix.target }}
         platforms: linux/amd64,linux/arm64, linux/arm/v7
         push: true
         tags: |
-         ghcr.io/kdeal/devenv:latest
+         ghcr.io/kdeal/${{matrix.image}}:latest

--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:trixie AS go-base
 
-FROM ubuntu:noble
+FROM ubuntu:noble AS devenv-cs
 
 ENV USER_PATH=""
 
@@ -18,7 +18,6 @@ RUN set -eux; \
      git \
      man-db \
      nodejs npm \
-     openssh-server \
      podman \
      python3-pip \
      python3-virtualenv \
@@ -29,9 +28,6 @@ RUN set -eux; \
      wget; \
     yes | unminimize; \
     rm -rf /var/lib/apt/lists/*; \
-    sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config; \
-    # Remove default user to free up 1000 uid in case I want to use it
-    userdel ubuntu; \
     #
     # Install rust from https://github.com/rust-lang/docker-rust/blob/master/stable/bullseye/Dockerfile
     #
@@ -81,6 +77,17 @@ COPY --from=go-base /usr/local/go/ /usr/local/go/
 
 # Adjust global path
 RUN sed "s%PATH=\"%PATH=\"${USER_PATH}%" -i /etc/environment
+
+FROM devenv-cs AS devenv-ssh
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get -y install --no-install-recommends \
+     openssh-server; \
+    rm -rf /var/lib/apt/lists/*; \
+    sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config; \
+    # Remove default user to free up 1000 uid in case I want to use it
+    userdel ubuntu;
 
 COPY entrypoint.sh /tmp/
 


### PR DESCRIPTION
I don't need the extra ssh entrypoint when using this container for codespaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an SSH-enabled development environment variant as an alternative to the standard configuration, enabling greater flexibility in deployment and access options.

* **Chores**
  * Updated build system to support simultaneous generation of multiple development environment configurations through an optimized, multi-variant workflow process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->