### PR TITLE
Dev container changes

### DIFF
--- a/.devcontainer/default/devcontainer.json
+++ b/.devcontainer/default/devcontainer.json
@@ -7,6 +7,7 @@
         "seccomp=unconfined"
     ],
     "features": {
-        "sshd": "latest"
+        "ghcr.io/devcontainers/features/sshd:1": {},
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
     }
 }

--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:trixie AS go-base
 
-FROM ubuntu:noble AS devenv-cs
+FROM ubuntu:noble AS devenv-base
 
 ENV USER_PATH=""
 
@@ -8,24 +8,47 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     USER_PATH=~/.cargo/bin:/usr/local/cargo/bin:$USER_PATH \
-    RUST_VERSION=1.94.0
+    RUST_VERSION=1.94.0 \
+    SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F \
+    SWIFT_PLATFORM=ubuntu24.04 \
+    SWIFT_BRANCH=swift-6.3.3-release \
+    SWIFT_VERSION=swift-6.3.3-RELEASE \
+    SWIFT_WEBROOT=https://download.swift.org
 
 RUN set -eux; \
     apt-get update; \
     apt-get -y install --no-install-recommends \
+     binutils \
      build-essential \
      curl \
      git \
+     gnupg2 \
+     # Most of these are for swift
+     libedit2 \
+     libc6-dev \
+     libcurl4-openssl-dev \
+     libedit2 \
+     libgcc-13-dev \
+     libpython3-dev \
+     libsqlite3-0 \
+     libstdc++-13-dev \
+     libxml2-dev \
+     libncurses-dev \
+     libz3-dev \
+     pkg-config \
+     less \
+     jq \
      man-db \
      nodejs npm \
-     podman \
      python3-pip \
      python3-virtualenv \
      unminimize \
      rsync \
+     tzdata \
      unzip \
      vim \
-     wget; \
+     wget \
+     zlib1g-dev; \
     yes | unminimize; \
     rm -rf /var/lib/apt/lists/*; \
     #
@@ -66,7 +89,37 @@ RUN set -eux; \
     \
     rustup --version; \
     cargo --version; \
-    rustc --version;
+    rustc --version; \
+    #
+    # Install swift from https://github.com/swiftlang/swift-docker/blob/main/6.3/ubuntu/24.04/Dockerfile
+    # See vars above
+    #
+    ARCH_NAME="$(dpkg --print-architecture)"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'amd64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'arm64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
+    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
+    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+    # - Grab curl here so we cache better up above
+    && export DEBIAN_FRONTEND=noninteractive \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf swift.tar.gz --directory / --strip-components=1 \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz
+
 
 # Setup Go
 ENV GOLANG_VERSION=1.26.0
@@ -78,7 +131,27 @@ COPY --from=go-base /usr/local/go/ /usr/local/go/
 # Adjust global path
 RUN sed "s%PATH=\"%PATH=\"${USER_PATH}%" -i /etc/environment
 
-FROM devenv-cs AS devenv-ssh
+#
+# Codespaces Image
+#
+FROM devenv-base AS devenv-cs
+LABEL \
+    devcontainer.metadata="[{\"containerUser\":\"ubuntu\",\"remoteUser\":\"ubuntu\"}]"
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get -y install --no-install-recommends \
+     sudo; \
+    rm -rf /var/lib/apt/lists/*; \
+    echo ubuntu ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/ubuntu; \
+    chmod 0440 /etc/sudoers.d/ubuntu;
+
+USER ubuntu
+
+#
+# SSH Image
+#
+FROM devenv-base AS devenv-ssh
 
 RUN set -eux; \
     apt-get update; \


### PR DESCRIPTION
- Switch to docker-outside-of-docker for instead of podman. I was having issues getting podman to run inside a container, so I gave up and switched back to docker
- Add less and jq since they are useful
- Add swift since I want to port wkfl to swift for reasons
- Use ubuntu user in the codespace version. Add sudo, so I can become root in codespaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Swift toolchain support to development environments, with architecture validation and installation verification.
  * Added Docker tooling for development containers.
  * Added improved Codespaces and SSH container support, including streamlined Ubuntu access and sudo configuration.

* **Improvements**
  * Updated development container components to use explicit, version-pinned configurations for more consistent setups.
  * Expanded the base development environment with additional system packages and shared tool configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->