### PR TITLE
Remove arm/v7 image from devenv images

### DIFF
--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         context: "{{defaultContext}}:devenv"
         target: ${{ matrix.target }}
-        platforms: linux/amd64,linux/arm64, linux/arm/v7
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: |
          ghcr.io/kdeal/${{matrix.image}}:latest


### PR DESCRIPTION
Everything should be running arm64 now and swift doesn't support arm/v7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image publishing to support `linux/amd64` and `linux/arm64` platforms.
  * Removed support for `linux/arm/v7` images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->