### PR TITLE
Initialize the swift version of the wkfl cli

### DIFF
--- a/wkfl_swift/.gitignore
+++ b/wkfl_swift/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/wkfl_swift/Package.resolved
+++ b/wkfl_swift/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "744516eb84fc673c72b333a8b5b1ca2c687692006bdedea2c0432cf1258dfc1c",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/wkfl_swift/Package.swift
+++ b/wkfl_swift/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 6.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "wkfl",
+    products: [
+        .library(name: "WkflLib", targets: ["WkflLib"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "WkflCli",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .target(name: "WkflLib"),
+            ]
+        ),
+        .testTarget(
+            name: "WkflTests",
+            dependencies: ["WkflCli", "WkflLib"]
+        ),
+        .target(name: "WkflLib"),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/wkfl_swift/Sources/WkflCli/WkflCLI.swift
+++ b/wkfl_swift/Sources/WkflCli/WkflCLI.swift
@@ -1,0 +1,11 @@
+import ArgumentParser
+
+@main
+struct wkfl: ParsableCommand {
+    @Flag(name: .shortAndLong, help: "Enable verbose (debug) logging output")
+    var verbose = false
+
+    public func run() throws {
+        print("Hello, world!")
+    }
+}

--- a/wkfl_swift/Tests/WkflTests/WkflTests.swift
+++ b/wkfl_swift/Tests/WkflTests/WkflTests.swift
@@ -1,0 +1,9 @@
+import Testing
+@testable import WkflCli
+@testable import WkflLib
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // Swift Testing Documentation
+    // https://swiftpackageindex.com/swiftlang/swift-testing/documentation
+}


### PR DESCRIPTION
I should probably setup ci for this too, but I will do this in another pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an initial Swift package with a reusable library and a command-line executable.
  - Introduced a `wkfl` CLI with a `--verbose` option.
- **Tests**
  - Added a basic Swift test target with placeholder test coverage.
- **Chores**
  - Added `.gitignore` rules for common macOS, Xcode, Swift Package Manager, and local credential artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->