### PR TITLE
DEA-10: Establish Swift package and source layout

### DIFF
--- a/wkfl_swift/Package.swift
+++ b/wkfl_swift/Package.swift
@@ -6,14 +6,14 @@ import PackageDescription
 let package = Package(
     name: "wkfl",
     products: [
-        .library(name: "WkflLib", targets: ["WkflLib"])
+        .executable(name: "wkfl", targets: ["WkflCli"]),
+        .library(name: "WkflLib", targets: ["WkflLib"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0")
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
+        .target(name: "WkflLib"),
         .executableTarget(
             name: "WkflCli",
             dependencies: [
@@ -22,10 +22,13 @@ let package = Package(
             ]
         ),
         .testTarget(
-            name: "WkflTests",
-            dependencies: ["WkflCli", "WkflLib"]
+            name: "WkflLibTests",
+            dependencies: ["WkflLib"]
         ),
-        .target(name: "WkflLib"),
+        .testTarget(
+            name: "WkflCliTests",
+            dependencies: ["WkflCli"]
+        ),
     ],
     swiftLanguageModes: [.v6]
 )

--- a/wkfl_swift/Sources/WkflCli/Commands/WkflCommand.swift
+++ b/wkfl_swift/Sources/WkflCli/Commands/WkflCommand.swift
@@ -1,0 +1,8 @@
+import ArgumentParser
+
+struct WkflCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "wkfl")
+
+    @Flag(name: .shortAndLong, help: "Enable verbose (debug) logging output")
+    var verbose = false
+}

--- a/wkfl_swift/Sources/WkflCli/WkflCLI.swift
+++ b/wkfl_swift/Sources/WkflCli/WkflCLI.swift
@@ -1,11 +1,8 @@
 import ArgumentParser
 
 @main
-struct wkfl: ParsableCommand {
-    @Flag(name: .shortAndLong, help: "Enable verbose (debug) logging output")
-    var verbose = false
-
-    public func run() throws {
-        print("Hello, world!")
+enum WkflCLI {
+    static func main() {
+        WkflCommand.main()
     }
 }

--- a/wkfl_swift/Tests/WkflCliTests/WkflCommandTests.swift
+++ b/wkfl_swift/Tests/WkflCliTests/WkflCommandTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import WkflCli
+
+@Test func rootCommandUsesExecutableName() {
+    #expect(WkflCommand.configuration.commandName == "wkfl")
+}
+
+@Test func verboseFlagParses() throws {
+    let command = try WkflCommand.parse(["--verbose"])
+
+    #expect(command.verbose)
+}

--- a/wkfl_swift/Tests/WkflLibTests/WkflLibTests.swift
+++ b/wkfl_swift/Tests/WkflLibTests/WkflLibTests.swift
@@ -1,0 +1,1 @@
+import WkflLib

--- a/wkfl_swift/Tests/WkflTests/WkflTests.swift
+++ b/wkfl_swift/Tests/WkflTests/WkflTests.swift
@@ -1,9 +1,0 @@
-import Testing
-@testable import WkflCli
-@testable import WkflLib
-
-@Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-    // Swift Testing Documentation
-    // https://swiftpackageindex.com/swiftlang/swift-testing/documentation
-}


### PR DESCRIPTION
Expose the wkfl executable product, isolate CLI command definitions, and split CLI and library tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `wkfl` executable command-line entry point.
  - Added a `--verbose`/`-v` option for enabling verbose output.
  - The CLI now uses the configured root command for execution.

- **Tests**
  - Added coverage for the command name and verbose option parsing.
  - Separated library and CLI test suites for clearer validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->