### PR TITLE
DEA-6: Add Swift CI

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -2,11 +2,21 @@ steps:
   - label: ":bricks: :white_check_mark: Linters for models project"
     key: "models_lint"
     command: |
-      apt update
-      apt install --yes just
       cd models/
       just check-stl
-    if_changed: "models/**"
+    if_changed: "{models/**,.buildkite/pipeline.yaml}"
     plugins:
       - docker#v5.13.0:
-          image: "debian:trixie"
+          image: "ghcr.io/kdeal/devenv-ci"
+          propagate-uid-gid: true
+
+  - label: ":swift: Swift CI (Linux)"
+    key: "wkfl_swift_linux"
+    command: |
+      cd wkfl_swift
+      just ci
+    if_changed: "{wkfl_swift/**,.buildkite/pipeline.yaml}"
+    plugins:
+      - docker#v5.13.0:
+          image: "ghcr.io/kdeal/devenv-ci"
+          propagate-uid-gid: true

--- a/wkfl_swift/Package.swift
+++ b/wkfl_swift/Package.swift
@@ -4,31 +4,31 @@
 import PackageDescription
 
 let package = Package(
-    name: "wkfl",
-    products: [
-        .executable(name: "wkfl", targets: ["WkflCli"]),
-        .library(name: "WkflLib", targets: ["WkflLib"]),
-    ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0")
-    ],
-    targets: [
+  name: "wkfl",
+  products: [
+    .executable(name: "wkfl", targets: ["WkflCli"]),
+    .library(name: "WkflLib", targets: ["WkflLib"]),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0")
+  ],
+  targets: [
+    .target(name: "WkflLib"),
+    .executableTarget(
+      name: "WkflCli",
+      dependencies: [
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .target(name: "WkflLib"),
-        .executableTarget(
-            name: "WkflCli",
-            dependencies: [
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .target(name: "WkflLib"),
-            ]
-        ),
-        .testTarget(
-            name: "WkflLibTests",
-            dependencies: ["WkflLib"]
-        ),
-        .testTarget(
-            name: "WkflCliTests",
-            dependencies: ["WkflCli"]
-        ),
-    ],
-    swiftLanguageModes: [.v6]
+      ]
+    ),
+    .testTarget(
+      name: "WkflLibTests",
+      dependencies: ["WkflLib"]
+    ),
+    .testTarget(
+      name: "WkflCliTests",
+      dependencies: ["WkflCli"]
+    ),
+  ],
+  swiftLanguageModes: [.v6]
 )

--- a/wkfl_swift/Sources/WkflCli/Commands/WkflCommand.swift
+++ b/wkfl_swift/Sources/WkflCli/Commands/WkflCommand.swift
@@ -1,8 +1,8 @@
 import ArgumentParser
 
 struct WkflCommand: ParsableCommand {
-    static let configuration = CommandConfiguration(commandName: "wkfl")
+  static let configuration = CommandConfiguration(commandName: "wkfl")
 
-    @Flag(name: .shortAndLong, help: "Enable verbose (debug) logging output")
-    var verbose = false
+  @Flag(name: .shortAndLong, help: "Enable verbose (debug) logging output")
+  var verbose = false
 }

--- a/wkfl_swift/Sources/WkflCli/WkflCLI.swift
+++ b/wkfl_swift/Sources/WkflCli/WkflCLI.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 
 @main
 enum WkflCLI {
-    static func main() {
-        WkflCommand.main()
-    }
+  static func main() {
+    WkflCommand.main()
+  }
 }

--- a/wkfl_swift/Tests/WkflCliTests/WkflCommandTests.swift
+++ b/wkfl_swift/Tests/WkflCliTests/WkflCommandTests.swift
@@ -1,12 +1,13 @@
 import Testing
+
 @testable import WkflCli
 
 @Test func rootCommandUsesExecutableName() {
-    #expect(WkflCommand.configuration.commandName == "wkfl")
+  #expect(WkflCommand.configuration.commandName == "wkfl")
 }
 
 @Test func verboseFlagParses() throws {
-    let command = try WkflCommand.parse(["--verbose"])
+  let command = try WkflCommand.parse(["--verbose"])
 
-    #expect(command.verbose)
+  #expect(command.verbose)
 }

--- a/wkfl_swift/justfile
+++ b/wkfl_swift/justfile
@@ -1,0 +1,16 @@
+format:
+    swift format --in-place --recursive Package.swift Sources Tests
+
+format-check:
+    swift format lint --strict --recursive Package.swift Sources Tests
+
+resolve:
+    swift package resolve
+
+build:
+    swift build
+
+test:
+    swift test
+
+ci: resolve build test


### PR DESCRIPTION
Run Swift package resolution, builds, and tests through a `just` target on the Buildkite Linux agent. Use the shared development CI image so the required Swift toolchain and `just` are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the CI container setup for model linters and enabled UID/GID propagation.
  - Added a new Swift CI step for Linux that runs the Swift CI workflow when Swift-related files change.

- **Tests**
  - Updated Swift CLI tests to run under the Swift `Testing` harness.

- **Style**
  - Reformatted the Swift package manifest and aligned CLI command/entry-point formatting for consistency.

- **Documentation**
  - Added a Swift task runner file with common commands for resolve, build, test, and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->