### PR TITLE
Add CLI runtime and test harness

### DIFF
--- a/wkfl_swift/Sources/WkflCli/Commands/WkflCommand.swift
+++ b/wkfl_swift/Sources/WkflCli/Commands/WkflCommand.swift
@@ -1,8 +1,18 @@
 import ArgumentParser
 
 struct WkflCommand: ParsableCommand {
-  static let configuration = CommandConfiguration(commandName: "wkfl")
+  static let configuration = CommandConfiguration(
+    commandName: "wkfl",
+    version: "0.1.4"
+  )
 
   @Flag(name: .shortAndLong, help: "Enable verbose (debug) logging output")
   var verbose = false
+
+  @Option(name: .long, help: "Write generated shell integration commands to this file")
+  var shellActionsFile: String?
+
+  mutating func run() throws {
+    throw ValidationError("Missing subcommand.")
+  }
 }

--- a/wkfl_swift/Sources/WkflCli/WkflCLI.swift
+++ b/wkfl_swift/Sources/WkflCli/WkflCLI.swift
@@ -1,8 +1,101 @@
 import ArgumentParser
+import Foundation
+
+#if os(Linux)
+  import Glibc
+#else
+  import Darwin
+#endif
+
+/// The runtime state supplied only to commands that require configuration or shell actions.
+struct WkflRuntimeContext {
+  let verbose: Bool
+  let shellActionsFile: String?
+}
+
+/// Commands that need runtime state opt in so help, completion, and TUI-only commands stay independent.
+protocol WkflRuntimeCommand: ParsableCommand {
+  mutating func run(using context: WkflRuntimeContext) throws
+}
+
+enum WkflCli {
+  @discardableResult
+  static func run<StandardOutput: TextOutputStream, StandardError: TextOutputStream>(
+    arguments: [String],
+    standardOutput: inout StandardOutput,
+    standardError: inout StandardError,
+    makeContext: (WkflRuntimeContext, any ParsableCommand) throws -> WkflRuntimeContext = {
+      context, _ in context
+    }
+  ) -> Int32 {
+    let command: any ParsableCommand
+
+    do {
+      command = try WkflCommand.parseAsRoot(arguments.map { $0 == "-V" ? "--version" : $0 })
+    } catch {
+      let parserExitCode = WkflCommand.exitCode(for: error).rawValue
+      let exitCode: Int32 = parserExitCode == 0 ? 0 : 2
+      let message = WkflCommand.fullMessage(for: error)
+      if exitCode == 0 {
+        write(message, to: &standardOutput)
+      } else {
+        write(message, to: &standardError)
+      }
+      return exitCode
+    }
+
+    do {
+      if var runtimeCommand = command as? any WkflRuntimeCommand {
+        let rootCommand = command as? WkflCommand
+        let context = WkflRuntimeContext(
+          verbose: rootCommand?.verbose ?? false,
+          shellActionsFile: rootCommand?.shellActionsFile
+        )
+        try runtimeCommand.run(using: makeContext(context, command))
+      } else {
+        var command = command
+        try command.run()
+      }
+      return 0
+    } catch {
+      let exitCode: Int32 = error is ValidationError ? 2 : WkflCommand.exitCode(for: error).rawValue
+      let message = WkflCommand.fullMessage(for: error)
+      if exitCode == 0 {
+        write(message, to: &standardOutput)
+      } else {
+        write(message, to: &standardError)
+      }
+      return exitCode
+    }
+  }
+
+  private static func write<Stream: TextOutputStream>(_ message: String, to stream: inout Stream) {
+    guard !message.isEmpty else { return }
+    stream.write(message)
+    if !message.hasSuffix("\n") {
+      stream.write("\n")
+    }
+  }
+}
+
+private struct FileHandleOutputStream: TextOutputStream {
+  let handle: FileHandle
+
+  mutating func write(_ string: String) {
+    handle.write(Data(string.utf8))
+  }
+}
 
 @main
 enum WkflCLI {
   static func main() {
-    WkflCommand.main()
+    var standardOutput = FileHandleOutputStream(handle: .standardOutput)
+    var standardError = FileHandleOutputStream(handle: .standardError)
+    let status = WkflCli.run(
+      arguments: Array(CommandLine.arguments.dropFirst()),
+      standardOutput: &standardOutput,
+      standardError: &standardError
+    )
+    exit(status)
   }
 }

--- a/wkfl_swift/Tests/WkflCliTests/WkflCommandTests.swift
+++ b/wkfl_swift/Tests/WkflCliTests/WkflCommandTests.swift
@@ -11,3 +11,69 @@ import Testing
 
   #expect(command.verbose)
 }
+
+@Test func shellActionsFileOptionParses() throws {
+  let command = try WkflCommand.parse(["--shell-actions-file", "actions.txt"])
+
+  #expect(command.shellActionsFile == "actions.txt")
+}
+
+@Test func versionWritesToInjectedStandardOutput() {
+  var standardOutput = ""
+  var standardError = ""
+
+  let status = WkflCli.run(
+    arguments: ["--version"],
+    standardOutput: &standardOutput,
+    standardError: &standardError
+  )
+
+  #expect(status == 0)
+  #expect(standardOutput == "0.1.4\n")
+  #expect(standardError.isEmpty)
+}
+
+@Test func shortVersionWritesToInjectedStandardOutput() {
+  var standardOutput = ""
+  var standardError = ""
+
+  let status = WkflCli.run(
+    arguments: ["-V"],
+    standardOutput: &standardOutput,
+    standardError: &standardError
+  )
+
+  #expect(status == 0)
+  #expect(standardOutput == "0.1.4\n")
+  #expect(standardError.isEmpty)
+}
+
+@Test func usageErrorsWriteToInjectedStandardError() {
+  var standardOutput = ""
+  var standardError = ""
+
+  let status = WkflCli.run(
+    arguments: ["--not-an-option"],
+    standardOutput: &standardOutput,
+    standardError: &standardError
+  )
+
+  #expect(status == 2)
+  #expect(standardOutput.isEmpty)
+  #expect(standardError.contains("Unknown option '--not-an-option'"))
+}
+
+@Test func rootWithoutSubcommandIsAUsageError() {
+  var standardOutput = ""
+  var standardError = ""
+
+  let status = WkflCli.run(
+    arguments: [],
+    standardOutput: &standardOutput,
+    standardError: &standardError
+  )
+
+  #expect(status == 2)
+  #expect(standardOutput.isEmpty)
+  #expect(standardError.contains("Missing subcommand."))
+}


### PR DESCRIPTION
Provide consistent parsing, exit handling, and injectable output streams. Normalize usage errors to exit status 2, preserve clean help and version output, and defer runtime context creation until a command needs it.

Support verbose and shell action file settings in the runtime context, and add the compatibility -V version alias.