### PR TITLE
Add ploywood gap bridge

### DIFF
--- a/models/plywood_gap_bridge.scad
+++ b/models/plywood_gap_bridge.scad
@@ -1,0 +1,63 @@
+// Plywood-gap bridge clip
+// Units: mm
+//
+// The left end clamps one 1/2 in plywood panel. Its lower rail crosses the
+// 1/8 in panel gap and supports the neighboring replacement panel from below.
+
+part_length = 200;
+
+plywood_thickness = 12.7;  // 1/2 in
+board_gap = 3.175;         // 1/8 in
+fit_clearance = 0.35;
+
+wall_thickness = 3;
+capture_depth = 20;
+rest_depth = 20;
+edge_taper = 4;
+
+// The lower rail sits directly under both panels. The upper rail provides the
+// clearance needed to slide the clamp over the fixed plywood panel.
+lower_rail_top = 0;
+lower_rail_bottom = lower_rail_top - wall_thickness;
+upper_rail_bottom = plywood_thickness + fit_clearance;
+upper_rail_top = upper_rail_bottom + wall_thickness;
+replacement_end = -(board_gap + rest_depth);
+
+module bridge_profile() {
+  union() {
+    // Lower rail under the captured panel, opening toward positive x.
+    polygon(points = [
+      [0, lower_rail_bottom],
+      [capture_depth - edge_taper, lower_rail_bottom],
+      [capture_depth, lower_rail_top],
+      [0, lower_rail_top]
+    ]);
+
+    // The bridge projects from the wall in the opposite direction. It crosses
+    // the panel gap and supports the replacement panel from below.
+    polygon(points = [
+      [replacement_end, lower_rail_top],
+      [replacement_end + edge_taper, lower_rail_bottom],
+      [0, lower_rail_bottom],
+      [0, lower_rail_top]
+    ]);
+
+    // Outside wall of the capture slot.
+    translate([0, lower_rail_top])
+      square([wall_thickness, upper_rail_top - lower_rail_top]);
+
+    // Upper rail: over the fixed panel only, completing the sliding clamp.
+    // The tapered inner end makes the panel edge easier to insert.
+    polygon(points = [
+      [0, upper_rail_bottom],
+      [capture_depth, upper_rail_bottom],
+      [capture_depth - edge_taper, upper_rail_top],
+      [0, upper_rail_top]
+    ]);
+  }
+}
+
+// Extruding the sideways-h profile makes a 200 mm-long bridge.
+rotate([0, 90, 0])
+  linear_extrude(height = part_length)
+    bridge_profile();

--- a/models/plywood_gap_bridge.stl
+++ b/models/plywood_gap_bridge.stl
@@ -1,0 +1,254 @@
+solid OpenSCAD_Model
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 13.049999997019768 -20
+      vertex 200 13.049999997019768 -3
+      vertex 0 13.049999997019768 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 13.049999997019768 -20
+      vertex 200 13.049999997019768 -20
+      vertex 200 13.049999997019768 -3
+    endloop
+  endfacet
+  facet normal 0 0.8 -0.6
+    outer loop
+      vertex 0 16.049999997019768 -16
+      vertex 200 13.049999997019768 -20
+      vertex 0 13.049999997019768 -20
+    endloop
+  endfacet
+  facet normal 0 0.8 -0.6
+    outer loop
+      vertex 0 16.049999997019768 -16
+      vertex 200 16.049999997019768 -16
+      vertex 200 13.049999997019768 -20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 16.049999997019768 0
+      vertex 200 16.049999997019768 -16
+      vertex 0 16.049999997019768 -16
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 16.049999997019768 0
+      vertex 200 16.049999997019768 0
+      vertex 200 16.049999997019768 -16
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0
+      vertex 200 16.049999997019768 0
+      vertex 0 16.049999997019768 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0
+      vertex 200 0 0
+      vertex 200 16.049999997019768 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 0 23.174999997019768
+      vertex 200 0 0
+      vertex 0 0 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 0 23.174999997019768
+      vertex 200 0 23.174999997019768
+      vertex 200 0 0
+    endloop
+  endfacet
+  facet normal 0 -0.8 0.6
+    outer loop
+      vertex 0 -3 19.174999997019768
+      vertex 200 0 23.174999997019768
+      vertex 0 0 23.174999997019768
+    endloop
+  endfacet
+  facet normal 0 -0.8 0.6
+    outer loop
+      vertex 0 -3 19.174999997019768
+      vertex 200 -3 19.174999997019768
+      vertex 200 0 23.174999997019768
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 -3 -16
+      vertex 200 -3 19.174999997019768
+      vertex 0 -3 19.174999997019768
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 -3 -16
+      vertex 200 -3 -16
+      vertex 200 -3 19.174999997019768
+    endloop
+  endfacet
+  facet normal 0 -0.8 -0.6
+    outer loop
+      vertex 0 0 -20
+      vertex 200 -3 -16
+      vertex 0 -3 -16
+    endloop
+  endfacet
+  facet normal 0 -0.8 -0.6
+    outer loop
+      vertex 0 0 -20
+      vertex 200 0 -20
+      vertex 200 -3 -16
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 0 -3
+      vertex 200 0 -20
+      vertex 0 0 -20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 0 -3
+      vertex 200 0 -3
+      vertex 200 0 -20
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 13.049999997019768 -3
+      vertex 200 0 -3
+      vertex 0 0 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 13.049999997019768 -3
+      vertex 200 13.049999997019768 -3
+      vertex 200 0 -3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 16.049999997019768 -16
+      vertex 0 13.049999997019768 -20
+      vertex 0 13.049999997019768 -3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 16.049999997019768 0
+      vertex 0 16.049999997019768 -16
+      vertex 0 13.049999997019768 -3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 -3 19.174999997019768
+      vertex 0 0 23.174999997019768
+      vertex 0 0 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 -3
+      vertex 0 0 -20
+      vertex 0 -3 -16
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 16.049999997019768 0
+      vertex 0 13.049999997019768 -3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 13.049999997019768 -3
+      vertex 0 0 -3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 -3
+      vertex 0 -3 -16
+      vertex 0 -3 19.174999997019768
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 -3
+      vertex 0 -3 19.174999997019768
+      vertex 0 0 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 200 13.049999997019768 -3
+      vertex 200 13.049999997019768 -20
+      vertex 200 16.049999997019768 -16
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 200 13.049999997019768 -3
+      vertex 200 16.049999997019768 -16
+      vertex 200 16.049999997019768 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 200 0 0
+      vertex 200 0 23.174999997019768
+      vertex 200 -3 19.174999997019768
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 200 -3 -16
+      vertex 200 0 -20
+      vertex 200 0 -3
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 200 13.049999997019768 -3
+      vertex 200 16.049999997019768 0
+      vertex 200 0 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 200 0 -3
+      vertex 200 13.049999997019768 -3
+      vertex 200 0 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 200 -3 19.174999997019768
+      vertex 200 -3 -16
+      vertex 200 0 -3
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 200 0 0
+      vertex 200 -3 19.174999997019768
+      vertex 200 0 -3
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
I cut out a section of plywood and want to use this to allow putting the piece back in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a parametric 200 mm plywood-gap bridge clip model.
  * Included a ready-to-use 3D-printable STL mesh with sloped and rectangular surfaces.
  * Added adjustable dimensions, fit clearances, rail geometry, and tapered edges for customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->