### PR TITLE
Adjust wood thickness to 3/4" and increase taper

### DIFF
--- a/models/plywood_gap_bridge.scad
+++ b/models/plywood_gap_bridge.scad
@@ -6,14 +6,14 @@
 
 part_length = 200;
 
-plywood_thickness = 12.7;  // 1/2 in
+plywood_thickness = 19.05;  // 1/2 in
 board_gap = 3.175;         // 1/8 in
 fit_clearance = 0.35;
 
 wall_thickness = 3;
 capture_depth = 20;
 rest_depth = 20;
-edge_taper = 4;
+edge_taper = 8;
 
 // The lower rail sits directly under both panels. The upper rail provides the
 // clearance needed to slide the clamp over the fixed plywood panel.

--- a/models/plywood_gap_bridge.stl
+++ b/models/plywood_gap_bridge.stl
@@ -1,58 +1,58 @@
 solid OpenSCAD_Model
   facet normal 0 -1 0
     outer loop
-      vertex 0 13.049999997019768 -20
-      vertex 200 13.049999997019768 -3
-      vertex 0 13.049999997019768 -3
+      vertex 0 19.399999998509884 -20
+      vertex 200 19.399999998509884 -3
+      vertex 0 19.399999998509884 -3
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 0 13.049999997019768 -20
-      vertex 200 13.049999997019768 -20
-      vertex 200 13.049999997019768 -3
+      vertex 0 19.399999998509884 -20
+      vertex 200 19.399999998509884 -20
+      vertex 200 19.399999998509884 -3
     endloop
   endfacet
-  facet normal 0 0.8 -0.6
+  facet normal 0 0.9363291775690445 -0.3511234415883917
     outer loop
-      vertex 0 16.049999997019768 -16
-      vertex 200 13.049999997019768 -20
-      vertex 0 13.049999997019768 -20
+      vertex 0 22.399999998509884 -12
+      vertex 200 19.399999998509884 -20
+      vertex 0 19.399999998509884 -20
     endloop
   endfacet
-  facet normal 0 0.8 -0.6
+  facet normal 0 0.9363291775690445 -0.3511234415883917
     outer loop
-      vertex 0 16.049999997019768 -16
-      vertex 200 16.049999997019768 -16
-      vertex 200 13.049999997019768 -20
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0 16.049999997019768 0
-      vertex 200 16.049999997019768 -16
-      vertex 0 16.049999997019768 -16
+      vertex 0 22.399999998509884 -12
+      vertex 200 22.399999998509884 -12
+      vertex 200 19.399999998509884 -20
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 0 16.049999997019768 0
-      vertex 200 16.049999997019768 0
-      vertex 200 16.049999997019768 -16
+      vertex 0 22.399999998509884 0
+      vertex 200 22.399999998509884 -12
+      vertex 0 22.399999998509884 -12
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 22.399999998509884 0
+      vertex 200 22.399999998509884 0
+      vertex 200 22.399999998509884 -12
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex 0 0 0
-      vertex 200 16.049999997019768 0
-      vertex 0 16.049999997019768 0
+      vertex 200 22.399999998509884 0
+      vertex 0 22.399999998509884 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex 0 0 0
       vertex 200 0 0
-      vertex 200 16.049999997019768 0
+      vertex 200 22.399999998509884 0
     endloop
   endfacet
   facet normal 0 1 0
@@ -69,46 +69,46 @@ solid OpenSCAD_Model
       vertex 200 0 0
     endloop
   endfacet
-  facet normal 0 -0.8 0.6
+  facet normal 0 -0.9363291775690445 0.3511234415883917
     outer loop
-      vertex 0 -3 19.174999997019768
+      vertex 0 -3 15.174999997019768
       vertex 200 0 23.174999997019768
       vertex 0 0 23.174999997019768
     endloop
   endfacet
-  facet normal 0 -0.8 0.6
+  facet normal 0 -0.9363291775690445 0.3511234415883917
     outer loop
-      vertex 0 -3 19.174999997019768
-      vertex 200 -3 19.174999997019768
+      vertex 0 -3 15.174999997019768
+      vertex 200 -3 15.174999997019768
       vertex 200 0 23.174999997019768
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 0 -3 -16
-      vertex 200 -3 19.174999997019768
-      vertex 0 -3 19.174999997019768
+      vertex 0 -3 -12
+      vertex 200 -3 15.174999997019768
+      vertex 0 -3 15.174999997019768
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 0 -3 -16
-      vertex 200 -3 -16
-      vertex 200 -3 19.174999997019768
+      vertex 0 -3 -12
+      vertex 200 -3 -12
+      vertex 200 -3 15.174999997019768
     endloop
   endfacet
-  facet normal 0 -0.8 -0.6
+  facet normal 0 -0.9363291775690445 -0.3511234415883917
     outer loop
       vertex 0 0 -20
-      vertex 200 -3 -16
-      vertex 0 -3 -16
+      vertex 200 -3 -12
+      vertex 0 -3 -12
     endloop
   endfacet
-  facet normal 0 -0.8 -0.6
+  facet normal 0 -0.9363291775690445 -0.3511234415883917
     outer loop
       vertex 0 0 -20
       vertex 200 0 -20
-      vertex 200 -3 -16
+      vertex 200 -3 -12
     endloop
   endfacet
   facet normal 0 1 0
@@ -127,35 +127,35 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0 13.049999997019768 -3
+      vertex 0 19.399999998509884 -3
       vertex 200 0 -3
       vertex 0 0 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0 13.049999997019768 -3
-      vertex 200 13.049999997019768 -3
+      vertex 0 19.399999998509884 -3
+      vertex 200 19.399999998509884 -3
       vertex 200 0 -3
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 0 16.049999997019768 -16
-      vertex 0 13.049999997019768 -20
-      vertex 0 13.049999997019768 -3
+      vertex 0 22.399999998509884 -12
+      vertex 0 19.399999998509884 -20
+      vertex 0 19.399999998509884 -3
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 0 16.049999997019768 0
-      vertex 0 16.049999997019768 -16
-      vertex 0 13.049999997019768 -3
+      vertex 0 22.399999998509884 0
+      vertex 0 22.399999998509884 -12
+      vertex 0 19.399999998509884 -3
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 0 -3 19.174999997019768
+      vertex 0 -3 15.174999997019768
       vertex 0 0 23.174999997019768
       vertex 0 0 0
     endloop
@@ -164,90 +164,90 @@ solid OpenSCAD_Model
     outer loop
       vertex 0 0 -3
       vertex 0 0 -20
-      vertex 0 -3 -16
+      vertex 0 -3 -12
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
       vertex 0 0 0
-      vertex 0 16.049999997019768 0
-      vertex 0 13.049999997019768 -3
+      vertex 0 22.399999998509884 0
+      vertex 0 19.399999998509884 -3
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
       vertex 0 0 0
-      vertex 0 13.049999997019768 -3
+      vertex 0 19.399999998509884 -3
       vertex 0 0 -3
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
       vertex 0 0 -3
-      vertex 0 -3 -16
-      vertex 0 -3 19.174999997019768
+      vertex 0 -3 -12
+      vertex 0 -3 15.174999997019768
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
       vertex 0 0 -3
-      vertex 0 -3 19.174999997019768
+      vertex 0 -3 15.174999997019768
       vertex 0 0 0
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 200 13.049999997019768 -3
-      vertex 200 13.049999997019768 -20
-      vertex 200 16.049999997019768 -16
+      vertex 200 19.399999998509884 -3
+      vertex 200 19.399999998509884 -20
+      vertex 200 22.399999998509884 -12
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 200 13.049999997019768 -3
-      vertex 200 16.049999997019768 -16
-      vertex 200 16.049999997019768 0
+      vertex 200 19.399999998509884 -3
+      vertex 200 22.399999998509884 -12
+      vertex 200 22.399999998509884 0
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
       vertex 200 0 0
       vertex 200 0 23.174999997019768
-      vertex 200 -3 19.174999997019768
+      vertex 200 -3 15.174999997019768
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 200 -3 -16
+      vertex 200 -3 -12
       vertex 200 0 -20
       vertex 200 0 -3
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 200 13.049999997019768 -3
-      vertex 200 16.049999997019768 0
+      vertex 200 19.399999998509884 -3
+      vertex 200 22.399999998509884 0
       vertex 200 0 0
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
       vertex 200 0 -3
-      vertex 200 13.049999997019768 -3
+      vertex 200 19.399999998509884 -3
       vertex 200 0 0
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 200 -3 19.174999997019768
-      vertex 200 -3 -16
+      vertex 200 -3 15.174999997019768
+      vertex 200 -3 -12
       vertex 200 0 -3
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
       vertex 200 0 0
-      vertex 200 -3 19.174999997019768
+      vertex 200 -3 15.174999997019768
       vertex 200 0 -3
     endloop
   endfacet


### PR DESCRIPTION
My guess about wood thickness was wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the plywood gap bridge design to support thicker 19.05 mm plywood.
  * Increased the edge taper for improved fit and clearance.
  * Revised the 3D geometry and mesh surfaces to reflect the updated dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->